### PR TITLE
hotfix/event-sink-itest: candidate names should not contain period character

### DIFF
--- a/event-sink/src/test/java/io/voting/persistence/eventsink/EventSinkApplicationTest.java
+++ b/event-sink/src/test/java/io/voting/persistence/eventsink/EventSinkApplicationTest.java
@@ -101,15 +101,15 @@ class EventSinkApplicationTest extends TestKafkaContext {
 
   static Stream<Arguments> testElectionCreateEvents() {
     return Stream.of(
-      Arguments.of(buildElectionCreate(Map.of(fake.harryPotter().house(), 0L, fake.harryPotter().character(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.hobbit().location(), 0L, fake.hobbit().character(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.lordOfTheRings().location(), 0L, fake.lordOfTheRings().character(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.friends().location(), 0L, fake.friends().character(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.howIMetYourMother().highFive(), 0L, fake.howIMetYourMother().character(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.lebowski().actor(), 0L, fake.lebowski().character(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.gameOfThrones().dragon(), 0L, fake.gameOfThrones().character(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.pokemon().location(), 0L, fake.pokemon().name(), 0L))),
-      Arguments.of(buildElectionCreate(Map.of(fake.leagueOfLegends().location(), 0L, fake.leagueOfLegends().champion(), 0L)))
+      Arguments.of(buildElectionCreate(Map.of(fake.harryPotter().house().replace(".", "_"), 0L, fake.harryPotter().character().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.hobbit().location().replace(".", "_"), 0L, fake.hobbit().character().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.lordOfTheRings().location().replace(".", "_"), 0L, fake.lordOfTheRings().character().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.friends().location().replace(".", "_"), 0L, fake.friends().character().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.howIMetYourMother().highFive().replace(".", "_"), 0L, fake.howIMetYourMother().character().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.lebowski().actor().replace(".", "_"), 0L, fake.lebowski().character().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.gameOfThrones().dragon().replace(".", "_"), 0L, fake.gameOfThrones().character().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.pokemon().location().replace(".", "_"), 0L, fake.pokemon().name().replace(".", "_"), 0L))),
+      Arguments.of(buildElectionCreate(Map.of(fake.leagueOfLegends().location().replace(".", "_"), 0L, fake.leagueOfLegends().champion().replace(".", "_"), 0L)))
     );
   }
 


### PR DESCRIPTION
Ensure random candidate names do not contain '.' character 
Avoid mongodb mapkey exception