### PR TITLE
EDV-58: fix consumer rebalance listener initOffsets

### DIFF
--- a/event-sink/src/main/java/io/voting/persistence/eventsink/receiver/CloudEventReceiver.java
+++ b/event-sink/src/main/java/io/voting/persistence/eventsink/receiver/CloudEventReceiver.java
@@ -32,7 +32,7 @@ public class CloudEventReceiver extends AbstractEventReceiver<String, CloudEvent
       final ConsumerRecords<String, PayloadOrError<CloudEvent>> cRecords = consumer.poll(duration);
       if (cRecords.isEmpty()) continue;
       for (final ConsumerRecord<String, PayloadOrError<CloudEvent>> cRecord : cRecords) {
-        log.debug("Received event record : {}", cRecord);
+        log.trace("Received event record : {}", cRecord);
         final ReceiveEvent<String, CloudEvent> receiveEvent = new ReceiveEvent<>(
                 cRecord.topic(), cRecord.partition(), cRecord.offset(), cRecord.timestamp(), cRecord.key(), cRecord.value()
         );

--- a/library/src/main/java/io/voting/common/library/kafka/clients/receiver/ReceiverRebalanceListener.java
+++ b/library/src/main/java/io/voting/common/library/kafka/clients/receiver/ReceiverRebalanceListener.java
@@ -39,8 +39,8 @@ public class ReceiverRebalanceListener<K, V> implements ConsumerRebalanceListene
   public void onPartitionsRevoked(Collection<TopicPartition> collection) {
     log.info("Receiver partitions revoked : committing consumed offsets for the following partitions (Revoked): {}", collection);
     for (final TopicPartition tp : collection) {
-      log.debug("Committing offsets prior to revoke : {}", progress);
       if (Objects.isNull(progress.get(tp))) continue;
+      log.debug("--- Committing : {} ---", Map.of(tp, progress.get(tp)));
       consumer.commitSync(Map.of(tp, progress.get(tp)));
       progress.remove(tp);
     }
@@ -57,7 +57,10 @@ public class ReceiverRebalanceListener<K, V> implements ConsumerRebalanceListene
 
   private void initOffset(final Set<TopicPartition> assignment) {
     for (final TopicPartition tp : assignment) {
-      addOffsetsToTrack(tp.topic(), tp.partition(), consumer.position(tp));
+      progress.put(
+              new TopicPartition(tp.topic(), tp.partition()),
+              new OffsetAndMetadata(consumer.position(tp), null)
+      );
     }
   }
 }


### PR DESCRIPTION
Do not +1 offset when consumer is being assigned partition
Reduce log level to trace