### PR TITLE
feature/refactor-ttl

### DIFF
--- a/election-integrity/pom.xml
+++ b/election-integrity/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.voting.streams</groupId>
     <artifactId>election-integrity</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/ElectionIntegrityTopology.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/ElectionIntegrityTopology.java
@@ -1,18 +1,12 @@
 package io.voting.streams.electionintegrity.topology;
 
 import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
 import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.common.library.models.Election;
 import io.voting.common.library.models.ElectionCreate;
-import io.voting.common.library.models.ElectionView;
 import io.voting.common.library.models.ElectionVote;
-import io.voting.streams.electionintegrity.model.ElectionHeartbeat;
 import io.voting.streams.electionintegrity.model.ElectionSummary;
-import io.voting.streams.electionintegrity.model.TTLSummary;
-import io.voting.streams.electionintegrity.topology.aggregate.TTLAggregator;
 import io.voting.streams.electionintegrity.topology.aggregate.VoteAggregator;
-import io.voting.streams.electionintegrity.topology.joiner.ElectionViewJoiner;
 import io.voting.streams.electionintegrity.topology.mappers.ElectionIdExtractor;
 import io.voting.streams.electionintegrity.topology.mappers.ElectionMapper;
 import io.voting.streams.electionintegrity.topology.mappers.ce.CEElectionMapper;
@@ -20,30 +14,25 @@ import io.voting.streams.electionintegrity.topology.mappers.ce.CETTLMapper;
 import io.voting.streams.electionintegrity.topology.mappers.ce.CEVoteMapper;
 import io.voting.streams.electionintegrity.topology.predicates.FirstVoteProcessor;
 import io.voting.streams.electionintegrity.topology.predicates.IllegalContentProcessor;
+import io.voting.streams.electionintegrity.topology.predicates.PendingElectionFilter;
+import io.voting.streams.electionintegrity.topology.predicates.cmd.CmdTypeFilter;
+import io.voting.streams.electionintegrity.topology.predicates.cmd.ElectionCmdFilter;
+import io.voting.streams.electionintegrity.topology.predicates.cmd.ViewCmdFilter;
+import io.voting.streams.electionintegrity.topology.predicates.cmd.VoteCmdFilter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
-import org.apache.kafka.streams.kstream.Suppressed;
-import org.apache.kafka.streams.kstream.TimeWindows;
-import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.ValueMapper;
-import org.apache.kafka.streams.state.KeyValueStore;
 
-import java.time.Duration;
 import java.util.Properties;
 
 @Slf4j
@@ -51,107 +40,81 @@ public final class ElectionIntegrityTopology {
 
   public static final Serde<String> stringSerde = Serdes.String();
   public static final Serde<CloudEvent> ceSerde = StreamUtils.getCESerde();
-  private static final Serde<ElectionView> electionViewSerde = StreamUtils.getJsonSerde(ElectionView.class);
+  private static final Produced<String, CloudEvent> PRODUCED_WITH_STR_CE = Produced.with(stringSerde, ceSerde);
+
+  private static final CmdTypeFilter CMD_ELECTION_FILTER = new ElectionCmdFilter();
+  private static final CmdTypeFilter CMD_VOTE_FILTER = new VoteCmdFilter();
+  private static final CmdTypeFilter CMD_VIEW_FILTER = new ViewCmdFilter();
 
   private static final Predicate<String, ElectionCreate> ILLEGAL_ELECTION_FILTER = new IllegalContentProcessor();
   private static final ValueMapper<Election, CloudEvent> LEGAL_ELECTION_CE_MAPPER = new CEElectionMapper();
+
   private static final Predicate<String, ElectionSummary> LEGAL_VOTE_FILTER = new FirstVoteProcessor();
   private static final Aggregator<String, ElectionVote, ElectionSummary> VOTE_AGGREGATOR = new VoteAggregator();
   private static final KeyValueMapper<String, ElectionSummary, String> VOTE_ELECTION_ID_EXTRACTOR = new ElectionIdExtractor();
   private static final ValueMapper<ElectionSummary, CloudEvent> LEGAL_VOTE_CE_MAPPER = new CEVoteMapper();
 
-  private static final ValueMapper<TTLSummary, CloudEvent> TTL_CE_MAPPER = new CETTLMapper();
-  private static final Aggregator<String, ElectionHeartbeat, TTLSummary> TTL_AGGREGATOR = new TTLAggregator();
-  // if there is no record w/ the same key on the right side of the join, then the right value is set to null
-  private static final ValueJoiner<CloudEvent, ElectionView, ElectionHeartbeat> ELECTION_VIEW_JOINER = new ElectionViewJoiner();
+  private static final ValueMapper<CloudEvent, CloudEvent> TTL_CE_MAPPER = new CETTLMapper();
+  private static final Predicate<String, CloudEvent> PENDING_ELECTION_FILTER = new PendingElectionFilter();
 
   private ElectionIntegrityTopology() {}
 
   public static Topology buildTopology(final StreamsBuilder builder, final Properties properties) {
     final String inputTopic = properties.getProperty("input.topic");
-
     final KStream<String, CloudEvent> commandStream = builder
-            .stream(inputTopic, Consumed.with(stringSerde, ceSerde));
+            .stream(inputTopic, Consumed.with(stringSerde, ceSerde).withName("election.cmd.src"));
 
-    final KStream<String, CloudEvent> electionCommands = commandStream.filter((k, ce) -> CloudEventTypes.ELECTION_CREATE_CMD.equals(ce.getType()));
-    final KStream<String, CloudEvent> voteCommands = commandStream
-            .filter((k, ce) -> CloudEventTypes.ELECTION_VOTE_CMD.equals(ce.getType()));
-    final KStream<String, CloudEvent> viewCommands = commandStream
-            .filter((k, ce) -> CloudEventTypes.ELECTION_VIEW_CMD.equals(ce.getType()));
+    final KStream<String, CloudEvent> electionCommands = commandStream.filter(CMD_ELECTION_FILTER, CMD_ELECTION_FILTER.name());
+    final KStream<String, CloudEvent> voteCommands = commandStream.filter(CMD_VOTE_FILTER, CMD_VOTE_FILTER.name());
+    final KStream<String, CloudEvent> viewCommands = commandStream.filter(CMD_VIEW_FILTER, CMD_VIEW_FILTER.name());
 
-    final KStream<String, CloudEvent> legalElectionStream = defineEIntegrity(properties, electionCommands);
-    final KStream<String, CloudEvent> legalVoteStream = defineVIntegrity(properties, voteCommands);
-    final KTable<String, ElectionView> electionViewState = defineElectionViewState(viewCommands);
-    defineElectionTTL(properties, legalElectionStream, legalVoteStream, viewCommands, electionViewState);
+    defineEIntegrity(properties, electionCommands);
+    defineVIntegrity(properties, voteCommands);
+    defineElectionTTL(properties, viewCommands);
 
     final Topology topology = builder.build();
     log.debug("=== Topology === \n{}", topology.describe());
     return topology;
   }
 
-  private static KTable<String, ElectionView> defineElectionViewState(KStream<String, CloudEvent> viewCommands) {
-    return viewCommands
-            .mapValues(ce -> StreamUtils.unwrapCloudEventData(ce.getData(), ElectionView.class))
-            .toTable(Named.as("election.view.table"), Materialized.<String, ElectionView, KeyValueStore<Bytes, byte[]>>as("election.views").withKeySerde(stringSerde).withValueSerde(StreamUtils.getJsonSerde(ElectionView.class)));
-  }
 
-  private static KStream<String, CloudEvent> defineEIntegrity(final Properties properties, final KStream<String, CloudEvent> electionCommands) {
+  private static void defineEIntegrity(final Properties properties, final KStream<String, CloudEvent> electionCommands) {
     final String electionOutputTopic = properties.getProperty("output.topic.elections");
     final ValueMapper<ElectionCreate, Election> electionEnrichment = new ElectionMapper(properties.getProperty("election.ttl"));
-    final KStream<String, CloudEvent> legalElectionStream = electionCommands
-            .mapValues(ce -> StreamUtils.unwrapCloudEventData(ce.getData(), ElectionCreate.class))
-            .filterNot(ILLEGAL_ELECTION_FILTER)
-            .mapValues(electionEnrichment)
-            .mapValues(LEGAL_ELECTION_CE_MAPPER)
-            .selectKey((k, v) -> v.getId());
-    legalElectionStream
-            .to(electionOutputTopic, Produced.with(stringSerde, ceSerde));
-    return legalElectionStream;
+    electionCommands
+            .mapValues(ce -> StreamUtils.unwrapCloudEventData(ce.getData(), ElectionCreate.class), Named.as("ei.unwrap.ce.data"))
+            .filterNot(ILLEGAL_ELECTION_FILTER, IllegalContentProcessor.name())
+            .mapValues(electionEnrichment, ElectionMapper.name())
+            .mapValues(LEGAL_ELECTION_CE_MAPPER, CEElectionMapper.name())
+            .selectKey((k, v) -> v.getId(), Named.as("ei.key.selector"))
+            .to(electionOutputTopic, PRODUCED_WITH_STR_CE.withName("ei.sink"));
+
   }
 
-  private static KStream<String, CloudEvent> defineVIntegrity(final Properties properties, final KStream<String, CloudEvent> voteCommands) {
+  private static void defineVIntegrity(final Properties properties, final KStream<String, CloudEvent> voteCommands) {
     final String votesOutputTopic = properties.getProperty("output.topic.votes");
-    final KStream<String, CloudEvent> legalVoteStream = voteCommands
-            .mapValues(ce -> StreamUtils.unwrapCloudEventData(ce.getData(), ElectionVote.class))
+    voteCommands
+            .mapValues(ce -> StreamUtils.unwrapCloudEventData(ce.getData(), ElectionVote.class), Named.as("vi.unwrap.ce.data"))
             .groupByKey()
             .aggregate(
                     VoteAggregator.initializer(),
                     VOTE_AGGREGATOR,
+                    VoteAggregator.name(),
                     VoteAggregator.materialize()
             )
-            .toStream()
-            .filter(LEGAL_VOTE_FILTER)
-            .selectKey(VOTE_ELECTION_ID_EXTRACTOR)
-            .mapValues(LEGAL_VOTE_CE_MAPPER);
-    legalVoteStream
-            .to(votesOutputTopic, Produced.with(stringSerde, ceSerde));
-    return legalVoteStream;
+            .toStream(Named.as("vi.integrity.aggregate.stream"))
+            .filter(LEGAL_VOTE_FILTER, FirstVoteProcessor.name())
+            .selectKey(VOTE_ELECTION_ID_EXTRACTOR, ElectionIdExtractor.name())
+            .mapValues(LEGAL_VOTE_CE_MAPPER, CEVoteMapper.name())
+            .to(votesOutputTopic, PRODUCED_WITH_STR_CE.withName("vi.sink"));
   }
 
-  public static void defineElectionTTL(final Properties properties,
-                                       final KStream<String, CloudEvent> legalElectionStream,
-                                       final KStream<String, CloudEvent> legalVoteStream,
-                                       final KStream<String, CloudEvent> viewCommands,
-                                       final KTable<String, ElectionView> electionViewState) {
-    final String electionTTLDuration = properties.getProperty("election.ttl");
+  private static void defineElectionTTL(final Properties properties, final KStream<String, CloudEvent> viewCommands) {
     final String electionOutputTopic = properties.getProperty("output.topic.elections");
-    final Duration windowDuration = Duration.parse(electionTTLDuration);
-    legalElectionStream
-            .merge(viewCommands)
-            .merge(legalVoteStream, Named.as("election.ttl.merge"))
-            .leftJoin(electionViewState, ELECTION_VIEW_JOINER, Joined.with(stringSerde, ceSerde, electionViewSerde))
-            .filter((eId, hb) -> hb.view() != ElectionView.CLOSED)
-            .groupByKey()
-            .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(windowDuration.toMillis())))
-            .aggregate(
-                    TTLAggregator.initializer(),
-                    TTL_AGGREGATOR,
-                    TTLAggregator.materialize()
-            )
-            .suppress(Suppressed.untilWindowCloses(Suppressed.BufferConfig.unbounded().shutDownWhenFull()).withName("election.ttl.suppress"))
-            .toStream()
-            .map((windowedKey, ttlSummary) -> new KeyValue<>(windowedKey.key(), TTL_CE_MAPPER.apply(ttlSummary)))
-            .to(electionOutputTopic, Produced.with(stringSerde, ceSerde));
+    viewCommands
+            .filter(PENDING_ELECTION_FILTER, PendingElectionFilter.name())
+            .mapValues(TTL_CE_MAPPER, CETTLMapper.name())
+            .to(electionOutputTopic, PRODUCED_WITH_STR_CE.withName("ttl.sink"));
   }
 
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/aggregate/VoteAggregator.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/aggregate/VoteAggregator.java
@@ -9,6 +9,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 @Slf4j
@@ -30,5 +31,9 @@ public class VoteAggregator implements Aggregator<String, ElectionVote, Election
     return Materialized.<String, ElectionSummary, KeyValueStore<Bytes, byte[]>>as("election.vote.aggregate")
             .withKeySerde(Serdes.String())
             .withValueSerde(StreamUtils.getJsonSerde(ElectionSummary.class));
+  }
+
+  public static Named name() {
+    return Named.as("vi.integrity.aggregator");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ElectionIdExtractor.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ElectionIdExtractor.java
@@ -3,6 +3,7 @@ package io.voting.streams.electionintegrity.topology.mappers;
 import io.voting.streams.electionintegrity.model.ElectionSummary;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Named;
 
 import java.util.Optional;
 
@@ -18,5 +19,9 @@ public class ElectionIdExtractor implements KeyValueMapper<String, ElectionSumma
             .filter(array -> array.length >= 2)
             .map(array -> array[1])
             .orElse(electionSummary.getVote().getElectionId());
+  }
+
+  public static Named name() {
+    return Named.as("vi.eid.extractor");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ElectionMapper.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ElectionMapper.java
@@ -5,6 +5,7 @@ import io.voting.common.library.models.ElectionCreate;
 import io.voting.common.library.models.ElectionStatus;
 import io.voting.streams.electionintegrity.topology.util.TTLPairs;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.javatuples.Pair;
 
@@ -57,5 +58,9 @@ public class ElectionMapper implements ValueMapper<ElectionCreate, Election> {
               return election;
             })
             .orElseThrow();
+  }
+
+  public static Named name() {
+    return Named.as("ei.legal.election.mapper");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CEElectionMapper.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CEElectionMapper.java
@@ -5,6 +5,7 @@ import io.voting.common.library.kafka.utils.CloudEventTypes;
 import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.common.library.models.Election;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.Named;
 
 @Slf4j
 public class CEElectionMapper implements CEMapper<Election> {
@@ -20,5 +21,9 @@ public class CEElectionMapper implements CEMapper<Election> {
             .build();
     log.trace("CE result : {}", event);
     return event;
+  }
+
+  public static Named name() {
+    return Named.as("ei.ce.mapper");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CETTLMapper.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CETTLMapper.java
@@ -2,21 +2,25 @@ package io.voting.streams.electionintegrity.topology.mappers.ce;
 
 import io.cloudevents.CloudEvent;
 import io.voting.common.library.kafka.utils.CloudEventTypes;
-import io.voting.streams.electionintegrity.model.TTLSummary;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.Named;
 
 @Slf4j
-public class CETTLMapper implements CEMapper<TTLSummary> {
+public class CETTLMapper implements CEMapper<CloudEvent> {
   @Override
-  public CloudEvent apply(TTLSummary ttlSummary) {
-    log.trace("Mapping TTLSummary ({}) into CloudEvent format", ttlSummary);
+  public CloudEvent apply(CloudEvent ce) {
+    log.trace("Mapping closable-election ({}) into CloudEvent format", ce.getId());
     final CloudEvent event = ceBuilder
             .withType(CloudEventTypes.ELECTION_EXPIRATION_EVENT)
-            .withId(ttlSummary.getElectionId())
-            .withSubject(ttlSummary.getElectionId())
-            .withData(ttlSummary.getElectionId().getBytes())
+            .withId(ce.getId())
+            .withSubject(ce.getId())
+            .withData(ce.getId().getBytes())
             .build();
     log.debug("Transformed CE Type {} : {}", CloudEventTypes.ELECTION_EXPIRATION_EVENT, event);
     return event;
+  }
+
+  public static Named name() {
+    return Named.as("ttl.ce.mapper");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CEVoteMapper.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CEVoteMapper.java
@@ -6,6 +6,7 @@ import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.common.library.models.ElectionVote;
 import io.voting.streams.electionintegrity.model.ElectionSummary;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.Named;
 
 @Slf4j
 public class CEVoteMapper implements CEMapper<ElectionSummary> {
@@ -23,5 +24,9 @@ public class CEVoteMapper implements CEMapper<ElectionSummary> {
 
     log.debug("Legal vote transformation result : {}", event);
     return event;
+  }
+
+  public static Named name() {
+    return Named.as("vi.ce.mapper");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/FirstVoteProcessor.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/FirstVoteProcessor.java
@@ -2,6 +2,7 @@ package io.voting.streams.electionintegrity.topology.predicates;
 
 import io.voting.streams.electionintegrity.model.ElectionSummary;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Predicate;
 
 @Slf4j
@@ -19,5 +20,9 @@ public class FirstVoteProcessor implements Predicate<String, ElectionSummary> {
       log.trace("Legal vote encountered for key ({}) : {}", key, electionSummary);
       return true;
     }
+  }
+
+  public static Named name() {
+    return Named.as("vi.vote.filter");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/IllegalContentProcessor.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/IllegalContentProcessor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.voting.common.library.models.ElectionCreate;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Predicate;
 
 import java.io.BufferedReader;
@@ -43,5 +44,9 @@ public class IllegalContentProcessor implements Predicate<String, ElectionCreate
       log.error("Error converting event into POJO : {}", electionCreate, e);
       return true;
     }
+  }
+
+  public static Named name() {
+    return Named.as("ei.integrity.filter");
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/PendingElectionFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/PendingElectionFilter.java
@@ -1,0 +1,19 @@
+package io.voting.streams.electionintegrity.topology.predicates;
+
+import io.cloudevents.CloudEvent;
+import io.voting.common.library.kafka.utils.StreamUtils;
+import io.voting.common.library.models.ElectionView;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Predicate;
+
+public class PendingElectionFilter implements Predicate<String, CloudEvent> {
+
+  @Override
+  public boolean test(final String k, final CloudEvent v) {
+    return ElectionView.PENDING == StreamUtils.unwrapCloudEventData(v.getData(), ElectionView.class);
+  }
+
+  public static Named name() {
+    return Named.as("ttl.pending.view.filter");
+  }
+}

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/CmdTypeFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/CmdTypeFilter.java
@@ -1,0 +1,16 @@
+package io.voting.streams.electionintegrity.topology.predicates.cmd;
+
+import io.cloudevents.CloudEvent;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Predicate;
+
+public interface CmdTypeFilter extends Predicate<String, CloudEvent> {
+
+  String ceTypeTarget();
+  Named name();
+
+  @Override
+  default boolean test(String s, CloudEvent cloudEvent) {
+    return ceTypeTarget().equals(cloudEvent.getType());
+  }
+}

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ElectionCmdFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ElectionCmdFilter.java
@@ -1,0 +1,16 @@
+package io.voting.streams.electionintegrity.topology.predicates.cmd;
+
+import io.voting.common.library.kafka.utils.CloudEventTypes;
+import org.apache.kafka.streams.kstream.Named;
+
+public class ElectionCmdFilter implements CmdTypeFilter {
+  @Override
+  public String ceTypeTarget() {
+    return CloudEventTypes.ELECTION_CREATE_CMD;
+  }
+
+  @Override
+  public Named name() {
+    return Named.as("ei.cmd.filter");
+  }
+}

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ViewCmdFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ViewCmdFilter.java
@@ -1,0 +1,16 @@
+package io.voting.streams.electionintegrity.topology.predicates.cmd;
+
+import io.voting.common.library.kafka.utils.CloudEventTypes;
+import org.apache.kafka.streams.kstream.Named;
+
+public class ViewCmdFilter implements CmdTypeFilter {
+  @Override
+  public String ceTypeTarget() {
+    return CloudEventTypes.ELECTION_VIEW_CMD;
+  }
+
+  @Override
+  public Named name() {
+    return Named.as("ttl.cmd.filter");
+  }
+}

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/VoteCmdFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/VoteCmdFilter.java
@@ -1,0 +1,16 @@
+package io.voting.streams.electionintegrity.topology.predicates.cmd;
+
+import io.voting.common.library.kafka.utils.CloudEventTypes;
+import org.apache.kafka.streams.kstream.Named;
+
+public class VoteCmdFilter implements CmdTypeFilter {
+  @Override
+  public String ceTypeTarget() {
+    return CloudEventTypes.ELECTION_VOTE_CMD;
+  }
+
+  @Override
+  public Named name() {
+    return Named.as("vi.cmd.filter");
+  }
+}

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestCEBuilder.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestCEBuilder.java
@@ -24,7 +24,7 @@ public class TestCEBuilder {
     return ceBuilder.withId("test").withType(CloudEventTypes.ELECTION_VOTE_CMD).withSubject("test").withData(StreamUtils.wrapCloudEventData(electionVote)).build();
   }
 
-  public static CloudEvent buildCE(final ElectionView electionView) {
-    return ceBuilder.withId("test").withType(CloudEventTypes.ELECTION_VIEW_CMD).withSubject("test").withData(StreamUtils.wrapCloudEventData(electionView)).build();
+  public static CloudEvent buildCE(final String key, final ElectionView electionView) {
+    return ceBuilder.withId(key).withType(CloudEventTypes.ELECTION_VIEW_CMD).withSubject(key).withData(StreamUtils.wrapCloudEventData(electionView)).build();
   }
 }


### PR DESCRIPTION
Tumbling windows was not the answer to expiring events 
Instead, use causal relationships - views < votes 
Stateless expiry strategy ensuring expired elections do not accept new votes and will eventually be seen as CLOSED from user POV  