### PR TITLE
feature/cloud-event-avro: replace json ce data with avro ce data  (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ An event-driven voting system adhering to the [CQRS design pattern](https://mart
 - [Project Lombok](https://projectlombok.org/)
 - [Apache Kafka](https://kafka.apache.org/)
 - [RSocket](https://rsocket.io/)
+- [Apache Avro](https://avro.apache.org/)
+- [cloudevents-kafka-avro-serializer](https://github.com/kattlo/cloudevents-kafka-avro-serializer)
 
 ### NodeJS
 - [React](https://react.dev/)

--- a/cmd-bridge/README.md
+++ b/cmd-bridge/README.md
@@ -24,7 +24,7 @@ rsc --debug --fnf \
     "author": "Leonardo",
     "title": "NBA Playoffs MVP",
     "description": "The best player in the NBA playoffs",
-    "category": "SPORTS",
+    "category": "Sports",
     "candidates": ["Luka Doncic", "Nikola Jokic", "Anthony Edwards", "Brunson"]
     }' \
   --stacktrace ws://cmd-bridge.test.nermdev.io/cmd

--- a/cmd-bridge/pom.xml
+++ b/cmd-bridge/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.voting.command</groupId>
     <artifactId>cmd-bridge</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -64,13 +64,21 @@
         <dependency>
             <groupId>io.voting.common</groupId>
             <artifactId>library</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-data-mongodb</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/cmd-bridge/src/main/java/io/voting/command/cmdbridge/config/KafkaConfig.java
+++ b/cmd-bridge/src/main/java/io/voting/command/cmdbridge/config/KafkaConfig.java
@@ -1,8 +1,11 @@
 package io.voting.command.cmdbridge.config;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.voting.command.cmdbridge.sender.CmdSender;
 import io.voting.common.library.kafka.clients.sender.EventSender;
+import io.voting.common.library.kafka.clients.serialization.avro.KafkaAvroCloudEventSerializer;
 import io.voting.common.library.kafka.clients.serialization.ce.CESerializer;
 import io.voting.common.library.models.ElectionVote;
 import lombok.Setter;
@@ -10,6 +13,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -45,18 +49,24 @@ public class KafkaConfig {
     Optional.ofNullable(System.getenv("POD_NAME"))
             .ifPresent(id -> config.put(ConsumerConfig.CLIENT_ID_CONFIG, id));
     config.putAll(producer);
+    config.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    config.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroCloudEventSerializer.class.getName());
     config.putIfAbsent(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
     config.putIfAbsent(ProducerConfig.ACKS_CONFIG, 1);
+    config.putIfAbsent(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false);
+    config.putIfAbsent(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
     if (config.containsKey("config.providers")) {
       config.computeIfPresent("sasl.jaas.config", configProviderReMap);
       config.computeIfPresent("ssl.truststore.password", configProviderReMap);
+      config.computeIfPresent("schema.registry.ssl.truststore.password", configProviderReMap);
+      config.computeIfPresent("schema.registry.basic.auth.user.info", configProviderReMap);
     }
     return config;
   }
 
   @Bean
   public Producer<String, CloudEvent> producer() {
-    final Producer<String, CloudEvent> kafkaProducer = new KafkaProducer<>(producerConfigs(), new StringSerializer(), new CESerializer());
+    final Producer<String, CloudEvent> kafkaProducer = new KafkaProducer<>(producerConfigs());
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
       kafkaProducer.flush();
       kafkaProducer.close();
@@ -67,7 +77,7 @@ public class KafkaConfig {
   @Bean
   public EventSender<String, CloudEvent> voteSender(final Producer<String, CloudEvent> producer) {
     return new CmdSender(
-            topics.getOrDefault("NEW_VOTE", "election.votes.raw"),
+            topics.getOrDefault("NEW_VOTE", "test.election.commands"),
             producer
     );
   }
@@ -75,7 +85,7 @@ public class KafkaConfig {
   @Bean
   public EventSender<String, CloudEvent> electionSender(final Producer<String, CloudEvent> producer) {
     return new CmdSender(
-            topics.getOrDefault("NEW_ELECTION", "election.requests.raw"),
+            topics.getOrDefault("NEW_ELECTION", "test.election.commands"),
             producer
     );
   }

--- a/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/CloudEventMapper.java
+++ b/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/CloudEventMapper.java
@@ -3,6 +3,8 @@ package io.voting.command.cmdbridge.mappers;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
 import io.voting.command.cmdbridge.CmdBridgeApplication;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
+import io.voting.events.cmd.CmdEvent;
 
 import java.net.URI;
 
@@ -13,5 +15,12 @@ public interface CloudEventMapper<K, V> {
           .withSource(URI.create("https://"+ CmdBridgeApplication.class.getSimpleName()));
 
   CloudEvent apply(K key, V value);
+
+  default AvroCloudEventData<CmdEvent> avroData(K key, V value) {
+    return new AvroCloudEventData<>(
+            format(key, value)
+    );
+  }
+  CmdEvent format(K key, V value);
 
 }

--- a/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/ElectionCreateCmdMapper.java
+++ b/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/ElectionCreateCmdMapper.java
@@ -1,25 +1,52 @@
 package io.voting.command.cmdbridge.mappers;
 
 import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
-import io.voting.common.library.kafka.utils.StreamUtils;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.models.ElectionCreate;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.enums.ElectionCategory;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
 
 @Slf4j
 public class ElectionCreateCmdMapper implements CloudEventMapper<String, ElectionCreate> {
 
   @Override
   public CloudEvent apply(String key, ElectionCreate electionCreate) {
-    log.trace("Applying transformation (K,V): {}, {}", key, electionCreate);
+    log.trace("Applying CE transformation (K,V): {}, {}", key, electionCreate);
     final CloudEvent event = ceBuilder
             .withId(key)
-            .withType(CloudEventTypes.ELECTION_CREATE_CMD)
+            .withType(CreateElection.class.getName())
             .withSubject(electionCreate.getCategory())
-            .withData(StreamUtils.wrapCloudEventData(electionCreate))
+            .withData(AvroCloudEventData.MIME_TYPE, avroData(key, electionCreate))
+            .withTime(OffsetDateTime.now())
             .build();
-    log.trace("Applied transformation: {}", event);
+    log.trace("Applied CE transformation: {}", event);
     return event;
+  }
+
+  @Override
+  public CmdEvent format(String key, ElectionCreate electionCreate) {
+    try {
+      ElectionCategory category = ElectionCategory.valueOf(electionCreate.getCategory());
+      return new CmdEvent(buildCreateElection(electionCreate, category));
+    } catch (IllegalArgumentException e) {
+      log.error("Unsupported ElectionCategory ({}) present in payload : {}", electionCreate.getCategory(), electionCreate);
+      return new CmdEvent(buildCreateElection(electionCreate, ElectionCategory.Unknown));
+    }
+  }
+
+  private CreateElection buildCreateElection(final ElectionCreate electionCreate, final ElectionCategory category) {
+    return CreateElection.newBuilder()
+            .setAuthor(electionCreate.getAuthor())
+            .setTitle(electionCreate.getTitle())
+            .setDescription(electionCreate.getDescription())
+            .setCategory(category)
+            .setCandidates(new ArrayList<>(electionCreate.getCandidates()))
+            .build();
   }
 
 }

--- a/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/ElectionViewCmdMapper.java
+++ b/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/ElectionViewCmdMapper.java
@@ -1,24 +1,46 @@
 package io.voting.command.cmdbridge.mappers;
 
 import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
-import io.voting.common.library.kafka.utils.StreamUtils;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.models.ElectionView;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.ViewElection;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.OffsetDateTime;
 
 @Slf4j
 public class ElectionViewCmdMapper implements CloudEventMapper<String, ElectionView> {
 
   @Override
   public CloudEvent apply(String key, ElectionView electionView) {
-    log.trace("Applying transformation (K,V): {}, {}", key, electionView);
+    log.trace("Applying CE transformation (K,V): {}, {}", key, electionView);
     final CloudEvent event = ceBuilder
             .withId(key)
-            .withType(CloudEventTypes.ELECTION_VIEW_CMD)
+            .withType(ViewElection.class.getName())
             .withSubject(key)
-            .withData(StreamUtils.wrapCloudEventData(electionView))
+            .withData(AvroCloudEventData.MIME_TYPE, avroData(key, electionView))
+            .withTime(OffsetDateTime.now())
             .build();
-    log.trace("Applied transformation: {}", event);
+    log.trace("Applied CE transformation: {}", event);
     return event;
+  }
+
+  @Override
+  public CmdEvent format(String electionId, ElectionView view) {
+    try {
+      io.voting.events.enums.ElectionView eView = io.voting.events.enums.ElectionView.valueOf(view.name());
+      return new CmdEvent(buildViewElection(electionId, eView));
+    } catch (IllegalArgumentException e) {
+      log.error("Unsupported election view ({}) present in election view payload", view.name());
+      return new CmdEvent(buildViewElection(electionId, io.voting.events.enums.ElectionView.UNKNOWN));
+    }
+  }
+
+  private ViewElection buildViewElection(final String electionId, final io.voting.events.enums.ElectionView view) {
+    return ViewElection.newBuilder()
+            .setEId(electionId)
+            .setView(view)
+            .build();
   }
 }

--- a/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/VoteCmdMapper.java
+++ b/cmd-bridge/src/main/java/io/voting/command/cmdbridge/mappers/VoteCmdMapper.java
@@ -1,25 +1,39 @@
 package io.voting.command.cmdbridge.mappers;
 
 import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
-import io.voting.common.library.kafka.utils.StreamUtils;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.models.ElectionVote;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.RegisterVote;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.OffsetDateTime;
 
 @Slf4j
 public class VoteCmdMapper implements CloudEventMapper<String, ElectionVote> {
 
   @Override
   public CloudEvent apply(String key, ElectionVote electionVote) {
-    log.trace("Applying transformation (K,V): {}, {}", key, electionVote);
+    log.trace("Applying CE transformation (K,V): {}, {}", key, electionVote);
     final CloudEvent event = ceBuilder
             .withId(key)
-            .withType(CloudEventTypes.ELECTION_VOTE_CMD)
+            .withType(RegisterVote.class.getName())
             .withSubject(electionVote.getElectionId())
-            .withData(StreamUtils.wrapCloudEventData(electionVote))
+            .withData(AvroCloudEventData.MIME_TYPE, avroData(key, electionVote))
+            .withTime(OffsetDateTime.now())
             .build();
-    log.trace("Applied transformation: {}", event);
+    log.trace("Applied CE transformation: {}", event);
     return event;
+  }
+
+  @Override
+  public CmdEvent format(String key, ElectionVote value) {
+    return new CmdEvent(
+            RegisterVote.newBuilder()
+                    .setEId(value.getElectionId())
+                    .setVotedFor(value.getVotedFor())
+                    .build()
+    );
   }
 
 }

--- a/cmd-bridge/src/main/resources/application-sandbox.yml
+++ b/cmd-bridge/src/main/resources/application-sandbox.yml
@@ -1,0 +1,26 @@
+spring:
+  rsocket:
+    server:
+      transport: websocket
+      mapping-path: /cmd
+      port: 7000
+
+kafka:
+  properties:
+    bootstrap.servers: localhost:9092
+    auto.register.schemas: false
+    use.latest.version: true
+    latest.compatibility.strict: false
+    schema.registry.url: http://localhost:8081
+    cloudevents.serializer.encoding: BINARY
+  producer:
+    linger.ms: 15
+    acks: all
+    enable.idempotence: true
+  topics:
+    NEW_VOTE: election.commands
+    NEW_ELECTION: election.commands
+    NEW_VIEW: election.commands
+
+
+

--- a/cmd-bridge/src/main/resources/application-test.yml
+++ b/cmd-bridge/src/main/resources/application-test.yml
@@ -13,13 +13,20 @@ kafka:
     security.protocol: SASL_PLAINTEXT
     sasl.mechanism: PLAIN
     sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="{file:/mnt/kafka-secrets/secrets.txt:username}" password="{file:/mnt/kafka-secrets/secrets.txt:password}";
+    schema.registry.url: https://sr.cfk.svc.cluster.local:8081
+    schema.registry.basic.auth.user.info: "{file:/mnt/kafka-secrets/secrets.txt:username}:{file:/mnt/kafka-secrets/secrets.txt:password}"
+    schema.registry.basic.auth.credentials.source: USER_INFO
+    schema.registry.ssl.truststore.location: /mnt/tls/truststore.jks
+    schema.registry.ssl.truststore.password: {file:/mnt/kafka-secrets/secrets.txt:trust_password}
+    auto.register.schemas: false
+    cloudevents.serializer.encoding: BINARY
   producer:
     linger.ms: 15
     acks: all
     enable.idempotence: true
   topics:
-    NEW_VOTE: test.election.commands
-    NEW_ELECTION: test.election.commands
+    NEW_VOTE: edv.election.commands
+    NEW_ELECTION: edv.election.commands
 
 
 

--- a/cmd-bridge/src/main/resources/log4j.properties
+++ b/cmd-bridge/src/main/resources/log4j.properties
@@ -16,8 +16,11 @@ log4j.appender.CCONFIG.layout.ConversionPattern=%d{yyyy-MM-dd hh:mm:ss}{CST} %co
 
 
 # app level
-log4j.logger.io.voting.command.cmdbridge=debug, QC
+log4j.logger.io.voting.command.cmdbridge=info, QC
 log4j.additivity.io.voting.command.cmdbridge=false
+
+log4j.logger.io.voting.common.library.kafka.clients.serialization.avro=debug, QC
+log4j.additivity.io.voting.common.library.kafka.clients.serialization.avro=false
 
 
 # producer config

--- a/cmd-bridge/src/test/java/io/voting/command/cmdbridge/controller/AvroCloudEventDataTest.java
+++ b/cmd-bridge/src/test/java/io/voting/command/cmdbridge/controller/AvroCloudEventDataTest.java
@@ -1,0 +1,93 @@
+package io.voting.command.cmdbridge.controller;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
+import io.voting.common.library.kafka.clients.serialization.avro.KafkaAvroCloudEventSerializer;
+
+import io.voting.events.enums.ElectionView;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class AvroCloudEventDataTest {
+
+
+
+//    @Test
+//    void test() throws ExecutionException, InterruptedException {
+//
+//        final Map<String, Object> configs = Map.of(
+//                "bootstrap.servers", "localhost:9092",
+//                "schema.registry.url", "http://localhost:8081",
+//                "auto.register.schemas", "false",
+////                KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true",
+//                CloudEventSerializer.ENCODING_CONFIG, "BINARY",
+//                "key.serializer", "org.apache.kafka.common.serialization.StringSerializer",
+//                "value.serializer", KafkaAvroCloudEventSerializer.class.getName()
+//        );
+////        final KafkaAvroCloudEventSerializer serializer = new KafkaAvroCloudEventSerializer();
+////        serializer.configure(configs, false);
+//        final Producer<String, CloudEvent> producer = new KafkaProducer<>(configs);
+//
+//        var valor = new CmdEventData(new ElectionVoteData("eId", "Foo"));
+//        var data = new AvroCloudEventData<>(valor);
+//        var evento = CloudEventBuilder
+//                .v1()
+//                .withId(UUID.randomUUID().toString())
+//                .withSource(URI.create("/exemplo/enviar"))
+//                .withType(valor.getCommand().getClass().getName())
+//                .withSubject("TEST")
+//                .withTime(OffsetDateTime.now())
+//                .withData(AvroCloudEventData.MIME_TYPE, data)
+//                .build();
+//        System.out.println(evento);
+//        final ProducerRecord<String, CloudEvent> producerRecord = new ProducerRecord<>("election.commands", evento);
+//        producer.send(producerRecord).get();
+//        Thread.sleep(1000);
+//
+//
+//        final CmdEventData electionCreate = new CmdEventData(new ElectionCreateData("nerm", "election titile", "desc", ElectionCategory.Gaming, Arrays.asList("Foo", "Bar")));
+//        final AvroCloudEventData<CmdEventData> eCreateData = new AvroCloudEventData<>(electionCreate);
+//        final CloudEvent ceElectionCreate = CloudEventBuilder.v1()
+//                .withId(UUID.randomUUID().toString())
+//                .withSource(URI.create("/exemplo/enviar"))
+//                .withType(electionCreate.getCommand().getClass().getName())
+//                .withSubject("TEST")
+//                .withTime(OffsetDateTime.now())
+//                .withData(AvroCloudEventData.MIME_TYPE, eCreateData)
+//                .build();
+//        producer.send(new ProducerRecord<>("election.commands", ceElectionCreate)).get();
+//        Thread.sleep(1000);
+//
+//        final CmdEventData cmdElectionView = new CmdEventData(new ElectionViewData("electionId", ElectionView.PENDING));
+//        final AvroCloudEventData<CmdEventData> eViewData = new AvroCloudEventData<>(cmdElectionView);
+//        final CloudEvent ceElectionView = CloudEventBuilder.v1()
+//                .withId(UUID.randomUUID().toString())
+//                .withSource(URI.create("/exemplo/enviar"))
+//                .withType(cmdElectionView.getCommand().getClass().getName())
+//                .withSubject("TEST")
+//                .withTime(OffsetDateTime.now())
+//                .withData(AvroCloudEventData.MIME_TYPE, eViewData)
+//                .build();
+//        producer.send(new ProducerRecord<>("election.commands", ceElectionView)).get();
+//        Thread.sleep(1000);
+//
+//
+//
+//
+//    }
+
+}

--- a/cmd-bridge/src/test/java/io/voting/command/cmdbridge/controller/framework/SchemaRegistryContainer.java
+++ b/cmd-bridge/src/test/java/io/voting/command/cmdbridge/controller/framework/SchemaRegistryContainer.java
@@ -1,0 +1,34 @@
+package io.voting.command.cmdbridge.controller.framework;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
+
+  public static final String SCHEMA_REGISTRY_IMAGE = "confluentinc/cp-schema-registry";
+  public static final int SCHEMA_REGISTRY_PORT = 8081;
+
+  public SchemaRegistryContainer() {
+    this("7.6.1");
+  }
+
+  public SchemaRegistryContainer(String version) {
+    super(SCHEMA_REGISTRY_IMAGE + ":" + version);
+
+    waitingFor(Wait.forHttp("/subjects").forStatusCode(200));
+    withExposedPorts(SCHEMA_REGISTRY_PORT);
+  }
+
+  public SchemaRegistryContainer withKafka(KafkaContainer kafka) {
+    return withKafkaC(kafka);
+  }
+
+  public SchemaRegistryContainer withKafkaC(KafkaContainer kafka) {
+    withNetwork(kafka.getNetwork());
+    withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry");
+    withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:"+SCHEMA_REGISTRY_PORT);
+    withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "kafka:19092");
+    return self();
+  }
+}

--- a/cmd-bridge/src/test/java/io/voting/command/cmdbridge/controller/framework/TestKafkaContext.java
+++ b/cmd-bridge/src/test/java/io/voting/command/cmdbridge/controller/framework/TestKafkaContext.java
@@ -1,17 +1,122 @@
 package io.voting.command.cmdbridge.controller.framework;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.cmd.ViewElection;
+import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 @Testcontainers
 public abstract class TestKafkaContext {
 
+  private static final String CMD_EVENT_SCHEMA = "{\"type\":\"record\",\"name\":\"CmdEvent\",\"namespace\":\"io.voting.events.cmd\",\"doc\":\"Events emitted from the cmd-bridge component\",\"fields\":[{\"name\":\"cmd\",\"type\":[\"io.voting.events.cmd.CreateElection\",\"io.voting.events.cmd.ViewElection\",\"io.voting.events.cmd.RegisterVote\"]}]}";
+
   public static final KafkaContainer kafkaContainer;
+  public static final SchemaRegistryContainer srContainer;
 
   static {
     kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"))
+            .withKraft()
+            .withListener(() -> "kafka:19092")
+            .withNetwork(Network.SHARED)
             .withEnv("KAFKA_NUM_PARTITIONS", "1");
     kafkaContainer.start();
+    srContainer = new SchemaRegistryContainer().withKafka(kafkaContainer);
+    srContainer.start();
+  }
+
+  public static String schemaRegistryUrl() {
+    return "http://" + srContainer.getHost() + ":" + srContainer.getFirstMappedPort();
+  }
+
+  public static void registerSchemas() {
+    try (final SchemaRegistryClient client = new CachedSchemaRegistryClient(schemaRegistryUrl(), 10)) {
+      registerEmbeddedOneOfs(client);
+      registerCmdEventSchema(client);
+      prettyPrintSchemas();
+    } catch (IOException e) {
+        throw new RuntimeException(e);
+    }
+  }
+
+  private static void prettyPrintSchemas() {
+    final RestTemplate restTemplate = new RestTemplate();
+    final ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      final String srResp = restTemplate.getForObject(TestKafkaContext.schemaRegistryUrl() + "/schemas", String.class);
+      System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectMapper.readTree(srResp)));
+    } catch (IOException e) {
+      System.err.println("Unexpected error while querying schema registry: " + e.getMessage());
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  private static void registerCmdEventSchema(final SchemaRegistryClient client) {
+    try {
+      final List<SchemaReference> references = Arrays.asList(
+              new SchemaReference(CreateElection.class.getName(), "create-election-cmd", 1),
+              new SchemaReference(ViewElection.class.getName(), "view-election-cmd", 1),
+              new SchemaReference(RegisterVote.class.getName(), "register-vote-cmd", 1)
+      );
+      final Map<String, String> resolvedReferences = Map.of(
+              CreateElection.class.getName(), CreateElection.getClassSchema().toString(),
+              ViewElection.class.getName(), ViewElection.getClassSchema().toString(),
+              RegisterVote.class.getName(), RegisterVote.getClassSchema().toString()
+      );
+      final AvroSchema cmdEventSchema = new AvroSchema(
+              CMD_EVENT_SCHEMA,
+              references,
+              resolvedReferences,
+              -1,
+              false
+      );
+      int cmdEventId = client.register("test.election.commands-value", cmdEventSchema, true);
+      System.out.println("Registered cmd-event: " + cmdEventId);
+
+    } catch (RestClientException e) {
+      System.err.println("RestClientException during registration of cmd-event schema : " + e.getMessage());
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      System.err.println("IOException during registration of cmd-event schema : " + e.getMessage());
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  private static void registerEmbeddedOneOfs(final SchemaRegistryClient client) {
+    try {
+
+      int viewElectionId = client.register("view-election-cmd", new AvroSchema(ViewElection.getClassSchema()));
+      System.out.println("Registered view election: " + viewElectionId);
+
+      int registerVoteId = client.register("register-vote-cmd", new AvroSchema(RegisterVote.getClassSchema()));
+      System.out.println("Registered register vote: " + registerVoteId);
+
+      int createElectionId = client.register("create-election-cmd", new AvroSchema(CreateElection.getClassSchema()));
+      System.out.println("Registered register vote: " + createElectionId);
+
+    } catch (RestClientException e) {
+      System.err.println("RestClientException during registration of embedded 'one-of' schemas : " + e.getMessage());
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      System.err.println("IO error during registration of embedded 'one-of' schemas : " + e.getMessage());
+      throw new RuntimeException(e);
+    }
+
   }
 }

--- a/cmd-bridge/src/test/resources/application.yml
+++ b/cmd-bridge/src/test/resources/application.yml
@@ -8,12 +8,16 @@ spring:
 kafka:
   properties:
     bootstrap.servers: bootstrap.replace.in.itest:443
+    auto.register.schemas: false
+    use.latest.version: true
+    latest.compatibility.strict: false
+    schema.registry.url: http://willbereplaced:8081
   producer:
     linger.ms: 1
     acks: all
   topics:
-    NEW_VOTE: test.election.votes.raw
-    NEW_ELECTION: test.election.requests.raw
+    NEW_VOTE: test.election.commands
+    NEW_ELECTION: test.election.commands
 
 
 

--- a/cmd-bridge/src/test/resources/log4j.properties
+++ b/cmd-bridge/src/test/resources/log4j.properties
@@ -1,0 +1,30 @@
+log4j.rootCategory=info, CONSOLE
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd hh:mm:ss}{CST} %color{%-5p} [%t] %c : %m%n
+log4j.appender.CONSOLE.threshold=trace
+
+
+log4j.appender.QC=org.apache.log4j.ConsoleAppender
+log4j.appender.QC.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.QC.layout.ConversionPattern=%d{yyyy-MM-dd hh:mm:ss}{CST} %color{%-5p} [%t] %c{1} : %color-green{%m%n}
+
+log4j.appender.CCONFIG=org.apache.log4j.ConsoleAppender
+log4j.appender.CCONFIG.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.CCONFIG.layout.ConversionPattern=%d{yyyy-MM-dd hh:mm:ss}{CST} %color{%-5p} [%t] %c{1} : %color-cyan{%m%n}
+
+
+# app level
+log4j.logger.io.voting.command.cmdbridge=debug, QC
+log4j.additivity.io.voting.command.cmdbridge=false
+
+log4j.logger.io.voting.common.library.kafka.clients.serialization.avro=debug, QC
+log4j.additivity.io.voting.common.library.kafka.clients.serialization.avro=false
+
+
+# producer config
+log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=info, CCONFIG
+log4j.additivity.org.apache.kafka.clients.producer.ProducerConfig=false
+
+

--- a/deploy/base/cmd-bridge/deployment.yml
+++ b/deploy/base/cmd-bridge/deployment.yml
@@ -45,11 +45,13 @@ spec:
         runAsUser: 1000
       containers:
         - name: cmd-bridge
-          image: registry.nermdev.io/apps/cmd-bridge
+          image: registry.nermdev.io/edv/cmd-bridge
           imagePullPolicy: Always
           volumeMounts:
             - name: kafka-secrets
               mountPath: /mnt/kafka-secrets
+            - name: tls
+              mountPath: /mnt/tls
           resources:
             requests:
               cpu: 1.0
@@ -61,3 +63,6 @@ spec:
         - name: kafka-secrets
           secret:
             secretName: kafka-secrets
+        - name: tls
+          secret:
+            secretName: tls-nermin

--- a/deploy/base/election-integrity/sts.yml
+++ b/deploy/base/election-integrity/sts.yml
@@ -27,12 +27,12 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - amd64
-                - key: node-role.kubernetes.io/master
-                  operator: DoesNotExist
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -47,7 +47,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: election-integrity
-          image: registry.nermdev.io/apps/election-integrity
+          image: registry.nermdev.io/edv/election-integrity
           imagePullPolicy: Always
           args:
             - /mnt/application/application.properties
@@ -72,6 +72,8 @@ spec:
               mountPath: /mnt/application
             - name: kafka-secrets
               mountPath: /mnt/kafka-secrets
+            - name: tls
+              mountPath: /mnt/tls
           resources:
             requests:
               cpu: 1.0
@@ -86,6 +88,9 @@ spec:
         - name: kafka-secrets
           secret:
             secretName: kafka-secrets
+        - name: tls
+          secret:
+            secretName: tls-nermin
   volumeClaimTemplates:
     - metadata:
         name: eintegrity-state

--- a/deploy/base/event-sink/deployment.yml
+++ b/deploy/base/event-sink/deployment.yml
@@ -22,11 +22,13 @@ spec:
     spec:
       containers:
         - name: event-sink
-          image: registry.nermdev.io/apps/event-sink
+          image: registry.nermdev.io/edv/event-sink
           imagePullPolicy: Always
           volumeMounts:
             - name: kafka-secrets
               mountPath: /mnt/kafka-secrets
+            - name: tls
+              mountPath: /mnt/tls
           resources:
             requests:
               cpu: 500m
@@ -38,6 +40,9 @@ spec:
         - name: kafka-secrets
           secret:
             secretName: kafka-secrets
+        - name: tls
+          secret:
+            secretName: tls-nermin
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/deploy/base/query-service/deployment.yml
+++ b/deploy/base/query-service/deployment.yml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: query-service
-          image: registry.nermdev.io/apps/query-service
+          image: registry.nermdev.io/edv/query-service
           imagePullPolicy: Always
           resources:
             requests:

--- a/deploy/environment/test/kustomization.yml
+++ b/deploy/environment/test/kustomization.yml
@@ -3,8 +3,6 @@ kind: Kustomization
 
 namespace: test
 
-commonLabels:
-  project: edv
 
 resources:
   - ../../overlay/test/client
@@ -16,12 +14,12 @@ resources:
 images:
   - name: registry.nermdev.io/apps/edv-client
     newTag: 0.0.1
-  - name: registry.nermdev.io/apps/cmd-bridge
-    newTag: 0.0.1-SNAPSHOT
-  - name: registry.nermdev.io/apps/election-integrity
-    newTag: 0.0.1-SNAPSHOT
-  - name: registry.nermdev.io/apps/event-sink
-    newTag: 0.0.1-SNAPSHOT
-  - name: registry.nermdev.io/apps/query-service
-    newTag: 0.0.1-SNAPSHOT
+  - name: registry.nermdev.io/edv/cmd-bridge
+    newTag: 0.1.0-SNAPSHOT
+  - name: registry.nermdev.io/edv/election-integrity
+    newTag: 0.1.0-SNAPSHOT
+  - name: registry.nermdev.io/edv/event-sink
+    newTag: 0.1.0-SNAPSHOT
+  - name: registry.nermdev.io/edv/query-service
+    newTag: 0.1.0-SNAPSHOT
 

--- a/deploy/overlay/test/election-integrity/application.properties
+++ b/deploy/overlay/test/election-integrity/application.properties
@@ -1,15 +1,22 @@
 config.providers=file
 config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider
 state.dir=/mnt/data/eintegrity
-application.id=test.election.integrity.001
+application.id=test.election.integrity
 bootstrap.servers=kafka.cfk.svc.cluster.local:9093
 security.protocol=SASL_PLAINTEXT
 sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="${file:/mnt/kafka-secrets/secrets.txt:username}" password="${file:/mnt/kafka-secrets/secrets.txt:password}";
-input.topic=test.election.commands
-output.topic.elections=test.election.requests
-output.topic.votes=test.election.votes
+input.topic=edv.election.commands
+output.topic=edv.election.events
 replication.factor=2
 cache.max.bytes.buffering=0
 linger.ms=10
-election.ttl=PT10M
+schema.registry.url=https://sr.cfk.svc.cluster.local:8081
+schema.registry.basic.auth.user.info=${file:/mnt/kafka-secrets/secrets.txt:username}:${file:/mnt/kafka-secrets/secrets.txt:password}
+schema.registry.basic.auth.credentials.source=USER_INFO
+schema.registry.ssl.truststore.location=/mnt/tls/truststore.jks
+schema.registry.ssl.truststore.password=${file:/mnt/kafka-secrets/secrets.txt:trust_password}
+auto.register.schemas=false
+specific.avro.reader=true
+cloudevents.serializer.encoding=BINARY
+#election.ttl=PT10M

--- a/election-integrity/README.md
+++ b/election-integrity/README.md
@@ -11,3 +11,81 @@ Kafka Streams application responsible for filtering-out invalid / illegal electi
 
 
 
+```
+Topologies:
+   Sub-topology: 0
+    Source: election.cmd.src (topics: [election.commands])
+      --> global.ce.upcast
+    Processor: global.ce.upcast (stores: [])
+      --> ttl.cmd.filter, vi.cmd.filter, ei.cmd.filter
+      <-- election.cmd.src
+    Processor: vi.cmd.filter (stores: [])
+      --> vi.unwrap.ce.data
+      <-- global.ce.upcast
+    Processor: vi.unwrap.ce.data (stores: [])
+      --> vi.dao.ce.data
+      <-- vi.cmd.filter
+    Processor: ei.cmd.filter (stores: [])
+      --> ei.unwrap.ce.data
+      <-- global.ce.upcast
+    Processor: vi.dao.ce.data (stores: [])
+      --> vi.integrity.aggregator
+      <-- vi.unwrap.ce.data
+    Processor: ei.unwrap.ce.data (stores: [])
+      --> ei.integrity.filter
+      <-- ei.cmd.filter
+    Processor: vi.integrity.aggregator (stores: [election.vote.aggregate])
+      --> vi.integrity.aggregate.stream
+      <-- vi.dao.ce.data
+    Processor: ei.integrity.filter (stores: [])
+      --> ei.legal.election.mapper
+      <-- ei.unwrap.ce.data
+    Processor: ttl.cmd.filter (stores: [])
+      --> ttl.unwrap.ce.data
+      <-- global.ce.upcast
+    Processor: vi.integrity.aggregate.stream (stores: [])
+      --> vi.vote.filter
+      <-- vi.integrity.aggregator
+    Processor: ei.legal.election.mapper (stores: [])
+      --> ei.ce.mapper
+      <-- ei.integrity.filter
+    Processor: ttl.unwrap.ce.data (stores: [])
+      --> ttl.pending.view.filter
+      <-- ttl.cmd.filter
+    Processor: vi.vote.filter (stores: [])
+      --> vi.eid.extractor
+      <-- vi.integrity.aggregate.stream
+    Processor: ei.ce.mapper (stores: [])
+      --> ei.key.selector
+      <-- ei.legal.election.mapper
+    Processor: ttl.pending.view.filter (stores: [])
+      --> ttl.ce.mapper
+      <-- ttl.unwrap.ce.data
+    Processor: vi.eid.extractor (stores: [])
+      --> vi.ce.mapper
+      <-- vi.vote.filter
+    Processor: ei.key.selector (stores: [])
+      --> ei.object.upcast
+      <-- ei.ce.mapper
+    Processor: ttl.ce.mapper (stores: [])
+      --> ttl.object.upcast
+      <-- ttl.pending.view.filter
+    Processor: vi.ce.mapper (stores: [])
+      --> vi.object.upcast
+      <-- vi.eid.extractor
+    Processor: ei.object.upcast (stores: [])
+      --> ei.sink
+      <-- ei.key.selector
+    Processor: ttl.object.upcast (stores: [])
+      --> ttl.sink
+      <-- ttl.ce.mapper
+    Processor: vi.object.upcast (stores: [])
+      --> vi.sink
+      <-- vi.ce.mapper
+    Sink: ei.sink (topic: election.events)
+      <-- ei.object.upcast
+    Sink: ttl.sink (topic: election.events)
+      <-- ttl.object.upcast
+    Sink: vi.sink (topic: election.events)
+      <-- vi.object.upcast
+```

--- a/election-integrity/pom.xml
+++ b/election-integrity/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.voting.streams</groupId>
     <artifactId>election-integrity</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.voting.common</groupId>
             <artifactId>library</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/ElectionIntegrityApplication.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/ElectionIntegrityApplication.java
@@ -1,5 +1,8 @@
 package io.voting.streams.electionintegrity;
 
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.streams.electionintegrity.topology.ElectionIntegrityTopology;
 import lombok.extern.slf4j.Slf4j;
@@ -51,11 +54,14 @@ public class ElectionIntegrityApplication {
   }
 
   private static KafkaStreams buildStreams(final Properties properties) {
-    if (Objects.isNull(properties.getProperty("input.topic")) || Objects.isNull(properties.getProperty("output.topic.elections")) || Objects.isNull(properties.getProperty("output.topic.votes"))) {
+    if (Objects.isNull(properties.getProperty("input.topic")) || Objects.isNull(properties.getProperty("output.topic"))) {
       throw new RuntimeException("Missing input/output topic configuration");
     }
 
     properties.putIfAbsent("election.ttl", "P1D"); // default 1D TTL
+    properties.putIfAbsent(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false);
+    properties.putIfAbsent(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    properties.putIfAbsent(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true);
 
     final Topology topology = ElectionIntegrityTopology.buildTopology(new StreamsBuilder(), properties);
     return new KafkaStreams(topology, properties);

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/ElectionIntegrityTopology.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/ElectionIntegrityTopology.java
@@ -1,10 +1,15 @@
 package io.voting.streams.electionintegrity.topology;
 
 import io.cloudevents.CloudEvent;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.utils.StreamUtils;
-import io.voting.common.library.models.Election;
-import io.voting.common.library.models.ElectionCreate;
 import io.voting.common.library.models.ElectionVote;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.cmd.ViewElection;
+import io.voting.events.integrity.NewElection;
 import io.voting.streams.electionintegrity.model.ElectionSummary;
 import io.voting.streams.electionintegrity.topology.aggregate.VoteAggregator;
 import io.voting.streams.electionintegrity.topology.mappers.ElectionIdExtractor;
@@ -37,40 +42,55 @@ import java.util.Properties;
 
 @Slf4j
 public final class ElectionIntegrityTopology {
+  private static final String INPUT_TOPIC_CONFIG = "input.topic";
+  private static final String OUTPUT_TOPIC_CONFIG = "output.topic";
+  private static final String ELECTION_TTL_CONFIG = "election.ttl";
 
-  public static final Serde<String> stringSerde = Serdes.String();
-  public static final Serde<CloudEvent> ceSerde = StreamUtils.getCESerde();
-  private static final Produced<String, CloudEvent> PRODUCED_WITH_STR_CE = Produced.with(stringSerde, ceSerde);
 
   private static final CmdTypeFilter CMD_ELECTION_FILTER = new ElectionCmdFilter();
   private static final CmdTypeFilter CMD_VOTE_FILTER = new VoteCmdFilter();
   private static final CmdTypeFilter CMD_VIEW_FILTER = new ViewCmdFilter();
 
-  private static final Predicate<String, ElectionCreate> ILLEGAL_ELECTION_FILTER = new IllegalContentProcessor();
-  private static final ValueMapper<Election, CloudEvent> LEGAL_ELECTION_CE_MAPPER = new CEElectionMapper();
+  private static final Predicate<String, CreateElection> ILLEGAL_ELECTION_FILTER = new IllegalContentProcessor();
+  private static final ValueMapper<NewElection, CloudEvent> LEGAL_ELECTION_CE_MAPPER = new CEElectionMapper();
 
   private static final Predicate<String, ElectionSummary> LEGAL_VOTE_FILTER = new FirstVoteProcessor();
   private static final Aggregator<String, ElectionVote, ElectionSummary> VOTE_AGGREGATOR = new VoteAggregator();
   private static final KeyValueMapper<String, ElectionSummary, String> VOTE_ELECTION_ID_EXTRACTOR = new ElectionIdExtractor();
   private static final ValueMapper<ElectionSummary, CloudEvent> LEGAL_VOTE_CE_MAPPER = new CEVoteMapper();
 
-  private static final ValueMapper<CloudEvent, CloudEvent> TTL_CE_MAPPER = new CETTLMapper();
-  private static final Predicate<String, CloudEvent> PENDING_ELECTION_FILTER = new PendingElectionFilter();
+  private static final ValueMapper<ViewElection, CloudEvent> TTL_CE_MAPPER = new CETTLMapper();
+  private static final Predicate<String, ViewElection> PENDING_ELECTION_FILTER = new PendingElectionFilter();
 
   private ElectionIntegrityTopology() {}
 
   public static Topology buildTopology(final StreamsBuilder builder, final Properties properties) {
-    final String inputTopic = properties.getProperty("input.topic");
+    final Serde<Object> avroCESerde = StreamUtils.getAvroCESerde(properties);
+    return getTopology(builder, properties, avroCESerde);
+  }
+
+  public static Topology buildTopology(final StreamsBuilder builder, final Properties properties, final SchemaRegistryClient client) {
+    final Serde<Object> avroCESerde = StreamUtils.getAvroCESerde(client, properties);
+    return getTopology(builder, properties, avroCESerde);
+  }
+
+
+  private static Topology getTopology(StreamsBuilder builder, Properties properties, Serde<Object> avroCESerde) {
+    final Produced<String, Object> producedAvroCE = Produced.with(Serdes.String(), avroCESerde);
+
+    final String inputTopic = properties.getProperty(INPUT_TOPIC_CONFIG);
     final KStream<String, CloudEvent> commandStream = builder
-            .stream(inputTopic, Consumed.with(stringSerde, ceSerde).withName("election.cmd.src"));
+            .stream(inputTopic, Consumed.with(Serdes.String(), avroCESerde).withName("election.cmd.src"))
+            .mapValues(CloudEvent.class::cast, Named.as("global.ce.upcast"));
+
 
     final KStream<String, CloudEvent> electionCommands = commandStream.filter(CMD_ELECTION_FILTER, CMD_ELECTION_FILTER.name());
     final KStream<String, CloudEvent> voteCommands = commandStream.filter(CMD_VOTE_FILTER, CMD_VOTE_FILTER.name());
     final KStream<String, CloudEvent> viewCommands = commandStream.filter(CMD_VIEW_FILTER, CMD_VIEW_FILTER.name());
 
-    defineEIntegrity(properties, electionCommands);
-    defineVIntegrity(properties, voteCommands);
-    defineElectionTTL(properties, viewCommands);
+    defineEIntegrity(properties, electionCommands, producedAvroCE);
+    defineVIntegrity(properties, voteCommands, producedAvroCE);
+    defineElectionTTL(properties, viewCommands, producedAvroCE);
 
     final Topology topology = builder.build();
     log.debug("=== Topology === \n{}", topology.describe());
@@ -78,23 +98,25 @@ public final class ElectionIntegrityTopology {
   }
 
 
-  private static void defineEIntegrity(final Properties properties, final KStream<String, CloudEvent> electionCommands) {
-    final String electionOutputTopic = properties.getProperty("output.topic.elections");
-    final ValueMapper<ElectionCreate, Election> electionEnrichment = new ElectionMapper(properties.getProperty("election.ttl"));
+  private static void defineEIntegrity(final Properties properties, final KStream<String, CloudEvent> electionCommands, final Produced<String, Object> producedAvroCE) {
+    final String electionOutputTopic = properties.getProperty(OUTPUT_TOPIC_CONFIG);
+    final ValueMapper<CreateElection, NewElection> electionEnrichment = new ElectionMapper(properties.getProperty(ELECTION_TTL_CONFIG));
     electionCommands
-            .mapValues(ce -> StreamUtils.unwrapCloudEventData(ce.getData(), ElectionCreate.class), Named.as("ei.unwrap.ce.data"))
+            .mapValues(ce -> (CreateElection) AvroCloudEventData.<CmdEvent>dataOf(ce.getData()).getCmd(), Named.as("ei.unwrap.ce.data"))
             .filterNot(ILLEGAL_ELECTION_FILTER, IllegalContentProcessor.name())
             .mapValues(electionEnrichment, ElectionMapper.name())
             .mapValues(LEGAL_ELECTION_CE_MAPPER, CEElectionMapper.name())
             .selectKey((k, v) -> v.getId(), Named.as("ei.key.selector"))
-            .to(electionOutputTopic, PRODUCED_WITH_STR_CE.withName("ei.sink"));
+            .mapValues(v -> (Object) v, Named.as("ei.object.upcast"))
+            .to(electionOutputTopic, producedAvroCE.withName("ei.sink"));
 
   }
 
-  private static void defineVIntegrity(final Properties properties, final KStream<String, CloudEvent> voteCommands) {
-    final String votesOutputTopic = properties.getProperty("output.topic.votes");
+  private static void defineVIntegrity(final Properties properties, final KStream<String, CloudEvent> voteCommands, final Produced<String, Object> producedAvroCE) {
+    final String votesOutputTopic = properties.getProperty(OUTPUT_TOPIC_CONFIG);
     voteCommands
-            .mapValues(ce -> StreamUtils.unwrapCloudEventData(ce.getData(), ElectionVote.class), Named.as("vi.unwrap.ce.data"))
+            .mapValues(ce -> (RegisterVote) AvroCloudEventData.<CmdEvent>dataOf(ce.getData()).getCmd(), Named.as("vi.unwrap.ce.data"))
+            .mapValues(rv -> ElectionVote.of(rv.getEId().toString(), rv.getVotedFor().toString()), Named.as("vi.dao.ce.data"))
             .groupByKey()
             .aggregate(
                     VoteAggregator.initializer(),
@@ -106,15 +128,18 @@ public final class ElectionIntegrityTopology {
             .filter(LEGAL_VOTE_FILTER, FirstVoteProcessor.name())
             .selectKey(VOTE_ELECTION_ID_EXTRACTOR, ElectionIdExtractor.name())
             .mapValues(LEGAL_VOTE_CE_MAPPER, CEVoteMapper.name())
-            .to(votesOutputTopic, PRODUCED_WITH_STR_CE.withName("vi.sink"));
+            .mapValues(v -> (Object) v, Named.as("vi.object.upcast"))
+            .to(votesOutputTopic, producedAvroCE.withName("vi.sink"));
   }
 
-  private static void defineElectionTTL(final Properties properties, final KStream<String, CloudEvent> viewCommands) {
-    final String electionOutputTopic = properties.getProperty("output.topic.elections");
+  private static void defineElectionTTL(final Properties properties, final KStream<String, CloudEvent> viewCommands, final Produced<String, Object> producedAvroCE) {
+    final String electionOutputTopic = properties.getProperty(OUTPUT_TOPIC_CONFIG);
     viewCommands
+            .mapValues(ce -> (ViewElection) AvroCloudEventData.<CmdEvent>dataOf(ce.getData()).getCmd(), Named.as("ttl.unwrap.ce.data"))
             .filter(PENDING_ELECTION_FILTER, PendingElectionFilter.name())
             .mapValues(TTL_CE_MAPPER, CETTLMapper.name())
-            .to(electionOutputTopic, PRODUCED_WITH_STR_CE.withName("ttl.sink"));
+            .mapValues(v -> (Object) v, Named.as("ttl.object.upcast"))
+            .to(electionOutputTopic, producedAvroCE.withName("ttl.sink"));
   }
 
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CEMapper.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CEMapper.java
@@ -2,6 +2,8 @@ package io.voting.streams.electionintegrity.topology.mappers.ce;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
+import io.voting.events.integrity.IntegrityEvent;
 import io.voting.streams.electionintegrity.topology.ElectionIntegrityTopology;
 import org.apache.kafka.streams.kstream.ValueMapper;
 
@@ -12,5 +14,13 @@ public interface CEMapper<T> extends ValueMapper<T, CloudEvent> {
   CloudEventBuilder ceBuilder = new CloudEventBuilder()
           .newBuilder()
           .withSource(URI.create("https://" + ElectionIntegrityTopology.class.getSimpleName()));
+
+  default AvroCloudEventData<IntegrityEvent> avroData(T value) {
+    return new AvroCloudEventData<>(
+            format(value)
+    );
+  }
+
+  IntegrityEvent format(T value);
 
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CETTLMapper.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/mappers/ce/CETTLMapper.java
@@ -1,26 +1,41 @@
 package io.voting.streams.electionintegrity.topology.mappers.ce;
 
 import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
+import io.voting.events.cmd.ViewElection;
+import io.voting.events.integrity.CloseElection;
+import io.voting.events.integrity.IntegrityEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.kstream.Named;
 
+import java.time.OffsetDateTime;
+
 @Slf4j
-public class CETTLMapper implements CEMapper<CloudEvent> {
+public class CETTLMapper implements CEMapper<ViewElection> {
   @Override
-  public CloudEvent apply(CloudEvent ce) {
-    log.trace("Mapping closable-election ({}) into CloudEvent format", ce.getId());
+  public CloudEvent apply(ViewElection ce) {
+    log.trace("Mapping closable-election ({}) into CloudEvent format", ce.getEId());
     final CloudEvent event = ceBuilder
-            .withType(CloudEventTypes.ELECTION_EXPIRATION_EVENT)
-            .withId(ce.getId())
-            .withSubject(ce.getId())
-            .withData(ce.getId().getBytes())
+            .withType(CloseElection.class.getName())
+            .withId(ce.getEId().toString())
+            .withSubject(ce.getEId().toString())
+            .withData(AvroCloudEventData.MIME_TYPE, avroData(ce))
+            .withTime(OffsetDateTime.now())
             .build();
-    log.debug("Transformed CE Type {} : {}", CloudEventTypes.ELECTION_EXPIRATION_EVENT, event);
+    log.debug("Transformed CE Type {} : {}", CloseElection.class.getName(), event);
     return event;
   }
 
   public static Named name() {
     return Named.as("ttl.ce.mapper");
+  }
+
+  @Override
+  public IntegrityEvent format(ViewElection value) {
+    return new IntegrityEvent(
+            CloseElection.newBuilder()
+                    .setEId(value.getEId())
+                    .build()
+    );
   }
 }

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/IllegalContentProcessor.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/IllegalContentProcessor.java
@@ -3,6 +3,7 @@ package io.voting.streams.electionintegrity.topology.predicates;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.voting.common.library.models.ElectionCreate;
+import io.voting.events.cmd.CreateElection;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Predicate;
@@ -10,11 +11,13 @@ import org.apache.kafka.streams.kstream.Predicate;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
 @Slf4j
-public class IllegalContentProcessor implements Predicate<String, ElectionCreate> {
+public class IllegalContentProcessor implements Predicate<String, CreateElection> {
 
   private final ObjectMapper mapper;
   private Pattern pattern;
@@ -36,9 +39,11 @@ public class IllegalContentProcessor implements Predicate<String, ElectionCreate
    * returns true when content contains illegal/invalid content
    */
   @Override
-  public boolean test(String s, ElectionCreate electionCreate) {
+  public boolean test(String s, CreateElection electionCreate) {
     try {
-      final String json = mapper.writeValueAsString(electionCreate).toLowerCase();
+      final List<String> candidates = electionCreate.getCandidates().stream().map(CharSequence::toString).toList();
+      ElectionCreate election = new ElectionCreate(electionCreate.getAuthor().toString(), electionCreate.getTitle().toString(), electionCreate.getDescription().toString(), electionCreate.getCategory().name(), candidates);
+      final String json = mapper.writeValueAsString(election).toLowerCase();
       return pattern.matcher(json).find();
     } catch (JsonProcessingException e) {
       log.error("Error converting event into POJO : {}", electionCreate, e);

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/PendingElectionFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/PendingElectionFilter.java
@@ -1,16 +1,15 @@
 package io.voting.streams.electionintegrity.topology.predicates;
 
-import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.utils.StreamUtils;
-import io.voting.common.library.models.ElectionView;
+import io.voting.events.cmd.ViewElection;
+import io.voting.events.enums.ElectionView;
 import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Predicate;
 
-public class PendingElectionFilter implements Predicate<String, CloudEvent> {
+public class PendingElectionFilter implements Predicate<String, ViewElection> {
 
   @Override
-  public boolean test(final String k, final CloudEvent v) {
-    return ElectionView.PENDING == StreamUtils.unwrapCloudEventData(v.getData(), ElectionView.class);
+  public boolean test(final String k, final ViewElection v) {
+    return ElectionView.PENDING == v.getView();
   }
 
   public static Named name() {

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ElectionCmdFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ElectionCmdFilter.java
@@ -1,12 +1,12 @@
 package io.voting.streams.electionintegrity.topology.predicates.cmd;
 
-import io.voting.common.library.kafka.utils.CloudEventTypes;
+import io.voting.events.cmd.CreateElection;
 import org.apache.kafka.streams.kstream.Named;
 
 public class ElectionCmdFilter implements CmdTypeFilter {
   @Override
   public String ceTypeTarget() {
-    return CloudEventTypes.ELECTION_CREATE_CMD;
+    return CreateElection.class.getName();
   }
 
   @Override

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ViewCmdFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/ViewCmdFilter.java
@@ -1,12 +1,12 @@
 package io.voting.streams.electionintegrity.topology.predicates.cmd;
 
-import io.voting.common.library.kafka.utils.CloudEventTypes;
+import io.voting.events.cmd.ViewElection;
 import org.apache.kafka.streams.kstream.Named;
 
 public class ViewCmdFilter implements CmdTypeFilter {
   @Override
   public String ceTypeTarget() {
-    return CloudEventTypes.ELECTION_VIEW_CMD;
+    return ViewElection.class.getName();
   }
 
   @Override

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/VoteCmdFilter.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/predicates/cmd/VoteCmdFilter.java
@@ -1,12 +1,12 @@
 package io.voting.streams.electionintegrity.topology.predicates.cmd;
 
-import io.voting.common.library.kafka.utils.CloudEventTypes;
+import io.voting.events.cmd.RegisterVote;
 import org.apache.kafka.streams.kstream.Named;
 
 public class VoteCmdFilter implements CmdTypeFilter {
   @Override
   public String ceTypeTarget() {
-    return CloudEventTypes.ELECTION_VOTE_CMD;
+    return RegisterVote.class.getName();
   }
 
   @Override

--- a/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/util/TTLPairs.java
+++ b/election-integrity/src/main/java/io/voting/streams/electionintegrity/topology/util/TTLPairs.java
@@ -9,10 +9,9 @@ public final class TTLPairs {
 
   private TTLPairs() {}
 
-  public static Pair<Long, Long> now(final Duration duration) {
-    final Instant now = Instant.now();
-    final long begin = now.toEpochMilli();
-    final long end = now.plus(duration).toEpochMilli();
+  public static Pair<Instant, Instant> now(final Duration duration) {
+    final Instant begin = Instant.now();
+    final Instant end = begin.plus(duration);
     return Pair.with(begin, end);
   }
 }

--- a/election-integrity/src/main/resources/application-sandbox.properties
+++ b/election-integrity/src/main/resources/application-sandbox.properties
@@ -1,9 +1,13 @@
 application.id=election.integrity.001
 bootstrap.servers=localhost:9092
 input.topic=election.commands
-output.topic.elections=election.requests
-output.topic.votes=election.votes
+output.topic=election.events
 replication.factor=1
 cache.max.bytes.buffering=0
 linger.ms=10
 election.ttl=PT10M
+schema.registry.url=http://localhost:8081
+cloudevents.serializer.encoding=BINARY
+auto.register.schemas=false
+use.latest.version=true
+latest.compatibility.strict=false

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/ElectionIntegrityApplicationTest.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/ElectionIntegrityApplicationTest.java
@@ -2,16 +2,22 @@ package io.voting.streams.electionintegrity;
 
 import com.github.javafaker.Faker;
 import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import io.voting.common.library.kafka.clients.sender.EventSender;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
+import io.voting.common.library.kafka.clients.serialization.avro.KafkaAvroCloudEventSerializer;
 import io.voting.common.library.kafka.models.ReceiveEvent;
 import io.voting.common.library.kafka.test.TestSender;
-import io.voting.common.library.kafka.utils.StreamUtils;
-import io.voting.common.library.models.ElectionStatus;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.enums.ElectionCategory;
+import io.voting.events.enums.ElectionStatus;
+import io.voting.events.integrity.IntegrityEvent;
+import io.voting.events.integrity.NewElection;
 import io.voting.streams.electionintegrity.framework.TestCEBuilder;
 import io.voting.streams.electionintegrity.framework.TestConsumerHelper;
 import io.voting.streams.electionintegrity.framework.TestKafkaContext;
-import io.voting.common.library.models.Election;
-import io.voting.common.library.models.ElectionCreate;
 import io.voting.streams.electionintegrity.topology.ElectionIntegrityTopology;
 import lombok.SneakyThrows;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -29,6 +35,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -52,22 +59,29 @@ class ElectionIntegrityApplicationTest extends TestKafkaContext {
 
   @BeforeAll
   static void init() {
-    consumerHelper = new TestConsumerHelper(kafkaContainer, TestConsumerHelper.OUTPUT_TOPIC_ELECTION);
-    final KafkaProducer<String, CloudEvent> producer = new KafkaProducer<>(
-            KafkaTestUtils.producerProps(kafkaContainer.getBootstrapServers()),
-            new StringSerializer(), StreamUtils.getCESerde().serializer()
-    );
-    testSender = new TestSender<>(TestConsumerHelper.INPUT_TOPIC, producer);
     properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "election.integrity."+ UUID.randomUUID());
     properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
     properties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 1);
     properties.put(ProducerConfig.LINGER_MS_CONFIG, 0);
     properties.put("cache.max.bytes.buffering", 0);
     properties.put("input.topic", TestConsumerHelper.INPUT_TOPIC);
-    properties.put("output.topic.elections", TestConsumerHelper.OUTPUT_TOPIC_ELECTION);
-    properties.put("output.topic.votes", "election.votes");
+    properties.put("output.topic", TestConsumerHelper.OUTPUT_TOPIC);
     properties.put("commit.interval.ms", 1000);
     properties.put("election.ttl", "PT5M");
+    properties.put(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    properties.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestKafkaContext.schemaRegistryUrl());
+    properties.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+    properties.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true");
+
+    consumerHelper = new TestConsumerHelper(kafkaContainer, TestConsumerHelper.OUTPUT_TOPIC);
+    final Map<String, Object> producerConfigs = KafkaTestUtils.producerProps(kafkaContainer.getBootstrapServers());
+    producerConfigs.put(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    producerConfigs.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestKafkaContext.schemaRegistryUrl());
+    producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroCloudEventSerializer.class);
+    final KafkaProducer<String, CloudEvent> producer = new KafkaProducer<>(producerConfigs);
+    testSender = new TestSender<>(TestConsumerHelper.INPUT_TOPIC, producer);
+
     final Topology topology = ElectionIntegrityTopology.buildTopology(new StreamsBuilder(), properties);
     app = new KafkaStreams(topology, properties);
     app.start();
@@ -88,17 +102,20 @@ class ElectionIntegrityApplicationTest extends TestKafkaContext {
 
   @ParameterizedTest
   @MethodSource
-  void testElection(ElectionCreate legalElection, ElectionCreate illegalElection) throws ExecutionException, InterruptedException {
+  void testElection(CreateElection legalElection, CreateElection illegalElection) throws ExecutionException, InterruptedException {
     testSender.send(UUID.randomUUID().toString(), TestCEBuilder.buildCE(legalElection)).get();
     testSender.send(UUID.randomUUID().toString(), TestCEBuilder.buildCE(illegalElection)).get();
 
-    final Election expected = Election.builder()
-            .author(legalElection.getAuthor())
-            .title(legalElection.getTitle())
-            .description(legalElection.getDescription())
-            .category(legalElection.getCategory())
-            .candidates(buildCandidateMap(legalElection.getCandidates()))
-            .status(ElectionStatus.OPEN)
+    final NewElection expected = NewElection.newBuilder()
+            .setId(UUID.randomUUID().toString())
+            .setAuthor(legalElection.getAuthor())
+            .setTitle(legalElection.getTitle())
+            .setDescription(legalElection.getDescription())
+            .setCategory(legalElection.getCategory())
+            .setCandidates(buildCandidateMap(legalElection.getCandidates()))
+            .setStatus(ElectionStatus.OPEN)
+            .setStartTs(Instant.now())
+            .setEndTs(Instant.now())
             .build();
 
     final ReceiveEvent<String, CloudEvent> actual = consumerHelper.getEvents().poll(5000, TimeUnit.MILLISECONDS);
@@ -106,13 +123,13 @@ class ElectionIntegrityApplicationTest extends TestKafkaContext {
     assertThat(actual).isNotNull();
 
     final CloudEvent actualPayload = actual.getPOrE().getPayload();
-    assertThat(StreamUtils.unwrapCloudEventData(actualPayload.getData(), Election.class))
+    assertThat((NewElection)AvroCloudEventData.<IntegrityEvent>dataOf(actualPayload.getData()).getLegalEvent())
             .satisfies(election -> assertThat(election.getId()).isNotNull())
             .satisfies(election -> assertThat(election.getAuthor()).isEqualTo(expected.getAuthor()))
             .satisfies(election -> assertThat(election.getTitle()).isEqualTo(expected.getTitle()))
             .satisfies(election -> assertThat(election.getDescription()).isEqualTo(expected.getDescription()))
             .satisfies(election -> assertThat(election.getCategory()).isEqualTo(expected.getCategory()))
-            .satisfies(election -> assertThat(election.getCandidates()).isEqualTo(expected.getCandidates()))
+            .satisfies(election -> assertThat(formatCandidateMap(election.getCandidates())).isEqualTo(formatCandidateMap(expected.getCandidates())))
             .satisfies(election -> assertThat(election.getStatus()).isEqualTo(expected.getStatus()))
             .satisfies(election -> assertThat(election.getEndTs()).isNotNull())
             .satisfies(election -> assertThat(election.getStartTs()).isNotNull());
@@ -132,21 +149,27 @@ class ElectionIntegrityApplicationTest extends TestKafkaContext {
     );
   }
 
-
-  private static ElectionCreate electionCreate(final String candidate) {
-    return new ElectionCreate(
-            fake.hobbit().character(),
-            fake.hobbit().location(),
-            fake.lorem().paragraph(),
-            "TEST",
-            Arrays.asList(fake.harryPotter().character(), fake.harryPotter().character(), Optional.ofNullable(candidate).orElse(fake.harryPotter().character()))
-    );
+  private static CreateElection electionCreate(final String candidate) {
+    return CreateElection.newBuilder()
+            .setAuthor(fake.hobbit().character())
+            .setTitle(fake.hobbit().location())
+            .setDescription(fake.lorem().paragraph())
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(Arrays.asList(fake.harryPotter().character(), fake.harryPotter().character(), Optional.ofNullable(candidate).orElse(fake.harryPotter().character())))
+            .build();
   }
 
-  private static Map<String, Long> buildCandidateMap(final List<String> candidates) {
-    final Map<String, Long> cMap = new HashMap<>();
+  private static Map<CharSequence, Long> buildCandidateMap(final List<CharSequence> candidates) {
+    final Map<CharSequence, Long> cMap = new HashMap<>();
     candidates.forEach(c -> cMap.put(c, 0L));
     return cMap;
+  }
+
+  private static Map<String, Long> formatCandidateMap(final Map<CharSequence, Long> candidates) {
+    final Map<String, Long> cMap = new HashMap<>();
+    candidates.forEach((k, v) -> cMap.put(k.toString(), v));
+    return cMap;
+
   }
 
 }

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/VoteIntegrityITest.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/VoteIntegrityITest.java
@@ -2,12 +2,18 @@ package io.voting.streams.electionintegrity;
 
 import com.github.javafaker.Faker;
 import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import io.voting.common.library.kafka.clients.sender.EventSender;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
+import io.voting.common.library.kafka.clients.serialization.avro.KafkaAvroCloudEventSerializer;
 import io.voting.common.library.kafka.models.PayloadOrError;
 import io.voting.common.library.kafka.models.ReceiveEvent;
 import io.voting.common.library.kafka.test.TestSender;
-import io.voting.common.library.kafka.utils.StreamUtils;
-import io.voting.common.library.models.ElectionVote;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.integrity.IntegrityEvent;
+import io.voting.events.integrity.NewVote;
 import io.voting.streams.electionintegrity.framework.TestCEBuilder;
 import io.voting.streams.electionintegrity.framework.TestConsumerHelper;
 import io.voting.streams.electionintegrity.framework.TestKafkaContext;
@@ -15,7 +21,6 @@ import io.voting.streams.electionintegrity.topology.ElectionIntegrityTopology;
 import lombok.SneakyThrows;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -29,6 +34,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -45,22 +51,30 @@ class VoteIntegrityITest extends TestKafkaContext {
 
   @BeforeAll
   static void init() {
-    consumerHelper = new TestConsumerHelper(kafkaContainer, TestConsumerHelper.OUTPUT_TOPIC_VOTES);
-    final KafkaProducer<String, CloudEvent> producer = new KafkaProducer<>(
-            KafkaTestUtils.producerProps(kafkaContainer.getBootstrapServers()),
-            new StringSerializer(), StreamUtils.getCESerde().serializer()
-    );
-    testSender = new TestSender<>(TestConsumerHelper.INPUT_TOPIC, producer);
     properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "election.integrity."+ UUID.randomUUID());
     properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
     properties.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 1);
     properties.put(ProducerConfig.LINGER_MS_CONFIG, 0);
     properties.put("cache.max.bytes.buffering", 0);
     properties.put("input.topic", TestConsumerHelper.INPUT_TOPIC);
-    properties.put("output.topic.elections", TestConsumerHelper.OUTPUT_TOPIC_ELECTION);
-    properties.put("output.topic.votes", "election.votes");
+    properties.put("output.topic", TestConsumerHelper.OUTPUT_TOPIC);
     properties.put("commit.interval.ms", 1000);
     properties.put("election.ttl", "PT5M");
+    properties.put(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    properties.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestKafkaContext.schemaRegistryUrl());
+    properties.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+    properties.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true");
+
+    consumerHelper = new TestConsumerHelper(kafkaContainer, TestConsumerHelper.OUTPUT_TOPIC);
+    final Map<String, Object> producerConfigs = KafkaTestUtils.producerProps(kafkaContainer.getBootstrapServers());
+    producerConfigs.put(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    producerConfigs.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, TestKafkaContext.schemaRegistryUrl());
+    producerConfigs.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, true);
+    producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroCloudEventSerializer.class);
+    final KafkaProducer<String, CloudEvent> producer = new KafkaProducer<>(producerConfigs);
+    testSender = new TestSender<>(TestConsumerHelper.INPUT_TOPIC, producer);
+
     final Topology topology = ElectionIntegrityTopology.buildTopology(new StreamsBuilder(), properties);
     app = new KafkaStreams(topology, properties);
     app.start();
@@ -92,29 +106,34 @@ class VoteIntegrityITest extends TestKafkaContext {
      */
     String eId = "111";
     for (int i = 0; i < 25; i++) {
-      testSender.send(eventKey(userId_1, eId), TestCEBuilder.buildCE(ElectionVote.of(eId, eCandidate))).get();
-      testSender.send(eventKey(userId_2, eId), TestCEBuilder.buildCE(ElectionVote.of(eId, eCandidate))).get();
-      testSender.send(eventKey(userId_3, eId), TestCEBuilder.buildCE(ElectionVote.of(eId, eCandidate))).get();
-      testSender.send(eventKey(userId_4, eId), TestCEBuilder.buildCE(ElectionVote.of(eId, eCandidate))).get();
+
+      testSender.send(eventKey(userId_1, eId), TestCEBuilder.buildCE(RegisterVote.newBuilder().setEId(eId).setVotedFor(eCandidate).build())).get();
+      testSender.send(eventKey(userId_2, eId), TestCEBuilder.buildCE(RegisterVote.newBuilder().setEId(eId).setVotedFor(eCandidate).build())).get();
+      testSender.send(eventKey(userId_3, eId), TestCEBuilder.buildCE(RegisterVote.newBuilder().setEId(eId).setVotedFor(eCandidate).build())).get();
+      testSender.send(eventKey(userId_4, eId), TestCEBuilder.buildCE(RegisterVote.newBuilder().setEId(eId).setVotedFor(eCandidate).build())).get();
       Thread.sleep(100);
     }
 
     final List<ReceiveEvent<String, CloudEvent>> actualEvents = new ArrayList<>();
     consumerHelper.getEvents().drainTo(actualEvents);
+    List<ReceiveEvent<String, CloudEvent>> actualTargetEvents = actualEvents.stream()
+            .filter(re -> NewVote.class.getName().equals(re.getPOrE().getPayload().getType()))
+            .toList();
 
-    assertThat(actualEvents).hasSize(4);
+    assertThat(actualTargetEvents).hasSize(4);
 
-    final Set<String> actualEventKeys = actualEvents.stream()
+    final Set<String> actualEventKeys = actualTargetEvents.stream()
             .map(ReceiveEvent::getKey)
             .collect(Collectors.toSet());
     assertThat(actualEventKeys).hasSize(1).containsOnly(eId);
 
-    final Set<String> actualVotedFor = actualEvents.stream()
+    final Set<String> actualVotedFor = actualTargetEvents.stream()
             .map(ReceiveEvent::getPOrE)
             .map(PayloadOrError::getPayload)
             .map(CloudEvent::getData)
-            .map(data -> StreamUtils.unwrapCloudEventData(data, ElectionVote.class))
-            .map(ElectionVote::getVotedFor)
+            .map(AvroCloudEventData::<IntegrityEvent>dataOf)
+            .map(integrityEvent -> (NewVote) integrityEvent.getLegalEvent())
+            .map(nv -> nv.getCandidate().toString())
             .collect(Collectors.toSet());
     assertThat(actualVotedFor).hasSize(1).containsOnly(eCandidate);
 

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/SchemaRegistryContainer.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/SchemaRegistryContainer.java
@@ -1,0 +1,34 @@
+package io.voting.streams.electionintegrity.framework;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
+
+  public static final String SCHEMA_REGISTRY_IMAGE = "confluentinc/cp-schema-registry";
+  public static final int SCHEMA_REGISTRY_PORT = 8081;
+
+  public SchemaRegistryContainer() {
+    this("7.6.1");
+  }
+
+  public SchemaRegistryContainer(String version) {
+    super(SCHEMA_REGISTRY_IMAGE + ":" + version);
+
+    waitingFor(Wait.forHttp("/subjects").forStatusCode(200));
+    withExposedPorts(SCHEMA_REGISTRY_PORT);
+  }
+
+  public SchemaRegistryContainer withKafka(KafkaContainer kafka) {
+    return withKafkaC(kafka);
+  }
+
+  public SchemaRegistryContainer withKafkaC(KafkaContainer kafka) {
+    withNetwork(kafka.getNetwork());
+    withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry");
+    withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:"+SCHEMA_REGISTRY_PORT);
+    withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "kafka:19092");
+    return self();
+  }
+}

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestCEBuilder.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestCEBuilder.java
@@ -2,28 +2,50 @@ package io.voting.streams.electionintegrity.framework;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.utils.CloudEventTypes;
 import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.common.library.models.ElectionCreate;
 import io.voting.common.library.models.ElectionView;
 import io.voting.common.library.models.ElectionVote;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.cmd.ViewElection;
 
 import java.net.URI;
+import java.time.OffsetDateTime;
 
 public class TestCEBuilder {
 
   public static final CloudEventBuilder ceBuilder = new CloudEventBuilder()
           .newBuilder()
+          .withTime(OffsetDateTime.now())
           .withSource(URI.create("https://" + "TEST"));
 
+  public static CloudEvent buildCE(final CreateElection electionCreate) {
+    return ceBuilder.withId("test").withType(CreateElection.class.getName()).withSubject("test").withData(AvroCloudEventData.MIME_TYPE, new AvroCloudEventData<>(new CmdEvent(electionCreate))).build();
+  }
+
+  public static CloudEvent buildCE(final RegisterVote electionVote) {
+    return ceBuilder.withId("test").withType(RegisterVote.class.getName()).withSubject("test").withData(AvroCloudEventData.MIME_TYPE, new AvroCloudEventData<>(new CmdEvent(electionVote))).build();
+  }
+
+  public static CloudEvent buildCE(final String key, final ViewElection viewElection) {
+    return ceBuilder.withId(key).withType(ViewElection.class.getName()).withSubject(key).withData(AvroCloudEventData.MIME_TYPE, new AvroCloudEventData<>(new CmdEvent(viewElection))).build();
+  }
+
+  @Deprecated
   public static CloudEvent buildCE(final ElectionCreate electionCreate) {
     return ceBuilder.withId("test").withType(CloudEventTypes.ELECTION_CREATE_CMD).withSubject("test").withData(StreamUtils.wrapCloudEventData(electionCreate)).build();
   }
 
+  @Deprecated
   public static CloudEvent buildCE(final ElectionVote electionVote) {
     return ceBuilder.withId("test").withType(CloudEventTypes.ELECTION_VOTE_CMD).withSubject("test").withData(StreamUtils.wrapCloudEventData(electionVote)).build();
   }
 
+  @Deprecated
   public static CloudEvent buildCE(final String key, final ElectionView electionView) {
     return ceBuilder.withId(key).withType(CloudEventTypes.ELECTION_VIEW_CMD).withSubject(key).withData(StreamUtils.wrapCloudEventData(electionView)).build();
   }

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestConsumerHelper.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestConsumerHelper.java
@@ -1,12 +1,14 @@
 package io.voting.streams.electionintegrity.framework;
 
 import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.clients.serialization.ce.CEPayloadDeserializer;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.voting.common.library.kafka.clients.serialization.ce.AvroCEPayloadDeserializer;
 import io.voting.common.library.kafka.models.PayloadOrError;
 import io.voting.common.library.kafka.models.ReceiveEvent;
 import lombok.Getter;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -20,18 +22,17 @@ import org.testcontainers.containers.KafkaContainer;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 public class TestConsumerHelper {
 
   public static final String INPUT_TOPIC = "election.requests.raw";
-  public static final String OUTPUT_TOPIC_ELECTION = "election.requests";
-  public static final String OUTPUT_TOPIC_VOTES = "election.votes";
+  public static final String OUTPUT_TOPIC = "election.events";
 
   static final NewTopic IN = new NewTopic(INPUT_TOPIC, 1, (short) 1);
-  static final NewTopic OUT = new NewTopic(OUTPUT_TOPIC_ELECTION, 1, (short) 1);
-  static final NewTopic OUT_VOTES = new NewTopic(OUTPUT_TOPIC_VOTES, 1, (short) 1);
+  static final NewTopic OUTPUT = new NewTopic(OUTPUT_TOPIC, 1, (short) 1);
 
 
   @Getter
@@ -40,9 +41,14 @@ public class TestConsumerHelper {
   public TestConsumerHelper(final KafkaContainer kafkaContainer, final String consumeTopic) {
     final Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(
             kafkaContainer.getBootstrapServers(),
-            "eiTest",
+            "eiTest" + UUID.randomUUID(),
             "true"
     );
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, AvroCEPayloadDeserializer.class.getName());
+    consumerProps.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,TestKafkaContext.schemaRegistryUrl());
+    consumerProps.put("specific.avro.reader", true);
+    consumerProps.put("auto.offset.reset", "latest");
     createTargetTopics(kafkaContainer);
 
     final KafkaMessageListenerContainer<String, PayloadOrError<CloudEvent>> listenerContainer = getListenerContainer(consumerProps, consumeTopic);
@@ -58,7 +64,7 @@ public class TestConsumerHelper {
 
   @NotNull
   private static KafkaMessageListenerContainer<String, PayloadOrError<CloudEvent>> getListenerContainer(Map<String, Object> consumerProps, String consumeTopic) {
-    final DefaultKafkaConsumerFactory<String, PayloadOrError<CloudEvent>> cf = new DefaultKafkaConsumerFactory<>(consumerProps, new StringDeserializer(), new CEPayloadDeserializer());
+    final DefaultKafkaConsumerFactory<String, PayloadOrError<CloudEvent>> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
     final ContainerProperties containerProperties = new ContainerProperties(consumeTopic);
     return new KafkaMessageListenerContainer<>(cf, containerProperties);
   }
@@ -76,9 +82,9 @@ public class TestConsumerHelper {
 
   private static void createTargetTopics(KafkaContainer kafkaContainer) {
     final KafkaAdmin kafkaAdmin = new KafkaAdmin(Map.of("bootstrap.servers", kafkaContainer.getBootstrapServers()));
-    kafkaAdmin.createOrModifyTopics(IN, OUT, OUT_VOTES);
+    kafkaAdmin.createOrModifyTopics(IN, OUTPUT);
     final Collection<TopicDescription> values = kafkaAdmin.describeTopics(
-            IN.name(), OUT.name(), OUT_VOTES.name()
+            IN.name(), OUTPUT.name()
     ).values();
     values.forEach(td -> System.out.println("TOPIC : " + td));
     kafkaAdmin.setCloseTimeout(1000);

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestKafkaContext.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/framework/TestKafkaContext.java
@@ -1,6 +1,7 @@
 package io.voting.streams.electionintegrity.framework;
 
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
@@ -8,11 +9,22 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class TestKafkaContext {
 
   public static final KafkaContainer kafkaContainer;
+  public static final SchemaRegistryContainer srContainer;
 
   static {
     kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"))
+            .withKraft()
+            .withListener(() -> "kafka:19092")
+            .withNetwork(Network.SHARED)
             .withEnv("KAFKA_NUM_PARTITIONS", "1");
     kafkaContainer.start();
+    srContainer = new SchemaRegistryContainer().withKafka(kafkaContainer);
+    srContainer.start();
+
+  }
+
+  public static String schemaRegistryUrl() {
+    return "http://" + srContainer.getHost() + ":" + srContainer.getFirstMappedPort();
   }
 
 }

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/ElectionIntegrityTopologyTest.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/ElectionIntegrityTopologyTest.java
@@ -2,10 +2,16 @@ package io.voting.streams.electionintegrity.topology;
 
 import com.github.javafaker.Faker;
 import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.utils.StreamUtils;
-import io.voting.common.library.models.Election;
-import io.voting.common.library.models.ElectionCreate;
-import io.voting.common.library.models.ElectionStatus;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.enums.ElectionCategory;
+import io.voting.events.integrity.IntegrityEvent;
+import io.voting.events.integrity.NewElection;
 import io.voting.streams.electionintegrity.framework.TestCEBuilder;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -21,10 +27,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,13 +42,13 @@ class ElectionIntegrityTopologyTest {
   static final String OUTPUT_TOPIC = "election.requests";
 
   static final Serde<String> STRING_SERDE = Serdes.String();
-  static final Serde<CloudEvent> CLOUD_EVENT_SERDE = StreamUtils.getCESerde();
+  static Serde<Object> CLOUD_EVENT_SERDE;
 
   static Topology topology;
   static Properties properties;
   TopologyTestDriver testDriver;
-  TestInputTopic<String, CloudEvent> inputTopic;
-  TestOutputTopic<String, CloudEvent> outputTopic;
+  TestInputTopic<String, Object> inputTopic;
+  TestOutputTopic<String, Object> outputTopic;
 
 
   @BeforeAll
@@ -48,12 +56,17 @@ class ElectionIntegrityTopologyTest {
     properties = new Properties();
     properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "election-integrity.test");
     properties.put("input.topic", INPUT_TOPIC);
-    properties.put("output.topic.elections", OUTPUT_TOPIC);
-    properties.put("output.topic.votes", "election.votes");
+    properties.put("output.topic", OUTPUT_TOPIC);
     properties.put("election.ttl", "P2D");
+    properties.put(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    properties.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://mock");
+    properties.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+    properties.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true");
+    MockSchemaRegistryClient srClient = new MockSchemaRegistryClient();
+    CLOUD_EVENT_SERDE = StreamUtils.getAvroCESerde(srClient, properties);
 
     final StreamsBuilder builder = new StreamsBuilder();
-    topology = ElectionIntegrityTopology.buildTopology(builder, properties);
+    topology = ElectionIntegrityTopology.buildTopology(builder, properties, srClient);
   }
 
   @BeforeEach
@@ -69,18 +82,36 @@ class ElectionIntegrityTopologyTest {
   @Test
   void test() {
     final Faker fake = Faker.instance();
-    final ElectionCreate legalElection = new ElectionCreate(fake.funnyName().name(), "Good Election", fake.lorem().paragraph(), "GOOD", Arrays.asList(fake.funnyName().name(), fake.funnyName().name()));
-    final ElectionCreate illegalElection = new ElectionCreate(fake.funnyName().name(), "Bad Election", fake.lorem().paragraph() + "ass", "TEST", Arrays.asList(fake.funnyName().name(), fake.funnyName().name(), "FUCK Cillary Hlinton"));
-    final Map<String, Long> candidateMap = new HashMap<>();
+
+    final CreateElection legalElection = CreateElection.newBuilder()
+            .setAuthor(fake.funnyName().name())
+            .setTitle("Good Election")
+            .setDescription(fake.lorem().paragraph())
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(Arrays.asList(fake.funnyName().name(), fake.funnyName().name()))
+            .build();
+
+    final CreateElection illegalElection = CreateElection.newBuilder()
+            .setAuthor(fake.funnyName().name())
+            .setTitle("Bad Election")
+            .setDescription(fake.lorem().paragraph() + "ass")
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(Arrays.asList(fake.funnyName().name(), fake.funnyName().name(), "Asshole Cillary Hlinton"))
+            .build();
+
+    final Map<CharSequence, Long> candidateMap = new HashMap<>();
     legalElection.getCandidates().forEach(c -> candidateMap.put(c, 0L));
 
-    final Election expected = Election.builder()
-            .author(legalElection.getAuthor())
-            .title(legalElection.getTitle())
-            .description(legalElection.getDescription())
-            .category(legalElection.getCategory())
-            .candidates(candidateMap)
-            .status(ElectionStatus.OPEN)
+    final NewElection expected = NewElection.newBuilder()
+            .setId(UUID.randomUUID().toString())
+            .setAuthor(legalElection.getAuthor())
+            .setTitle(legalElection.getTitle())
+            .setDescription(legalElection.getDescription())
+            .setCategory(legalElection.getCategory())
+            .setCandidates(candidateMap)
+            .setStatus(io.voting.events.enums.ElectionStatus.OPEN)
+            .setStartTs(Instant.now())
+            .setEndTs(Instant.now())
             .build();
 
 
@@ -90,17 +121,24 @@ class ElectionIntegrityTopologyTest {
     ));
 
     assertThat(outputTopic.getQueueSize()).isOne();
-    final CloudEvent actual = outputTopic.readKeyValue().value;
-    assertThat(StreamUtils.unwrapCloudEventData(actual.getData(), Election.class))
+    final CloudEvent actual = (CloudEvent) outputTopic.readKeyValue().value;
+    assertThat((NewElection) AvroCloudEventData.<IntegrityEvent>dataOf(actual.getData()).getLegalEvent())
             .satisfies(election -> assertThat(election.getId()).isNotNull())
             .satisfies(election -> assertThat(election.getAuthor()).isEqualTo(expected.getAuthor()))
             .satisfies(election -> assertThat(election.getTitle()).isEqualTo(expected.getTitle()))
             .satisfies(election -> assertThat(election.getDescription()).isEqualTo(expected.getDescription()))
             .satisfies(election -> assertThat(election.getCategory()).isEqualTo(expected.getCategory()))
-            .satisfies(election -> assertThat(election.getCandidates()).isEqualTo(expected.getCandidates()))
             .satisfies(election -> assertThat(election.getStatus()).isEqualTo(expected.getStatus()))
             .satisfies(election -> assertThat(election.getEndTs()).isNotNull())
-            .satisfies(election -> assertThat(election.getStartTs()).isNotNull());
+            .satisfies(election -> assertThat(election.getStartTs()).isNotNull())
+            .satisfies(election -> assertThat(getCandidateMap(election)).isEqualTo(getCandidateMap(expected)));
+  }
+
+  private Map<String, Long> getCandidateMap(NewElection exp) {
+    Map<CharSequence, Long> candidates = exp.getCandidates();
+    Map<String, Long> map = new HashMap<>();
+    candidates.keySet().forEach(cs -> map.put(cs.toString(), candidates.get(cs)));
+    return map;
   }
 
 

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/TTLTopologyTest.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/TTLTopologyTest.java
@@ -1,11 +1,19 @@
 package io.voting.streams.electionintegrity.topology;
 
 import io.cloudevents.CloudEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.utils.StreamUtils;
-import io.voting.common.library.models.ElectionCreate;
-import io.voting.common.library.models.ElectionView;
-import io.voting.common.library.models.ElectionVote;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.cmd.ViewElection;
+import io.voting.events.enums.ElectionCategory;
+import io.voting.events.enums.ElectionView;
+import io.voting.events.integrity.CloseElection;
+import io.voting.events.integrity.IntegrityEvent;
 import io.voting.streams.electionintegrity.framework.TestCEBuilder;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -28,17 +36,16 @@ import static org.assertj.core.api.Assertions.*;
 
 class TTLTopologyTest {
   static final String ELECTION_COMMANDS = "election.commands";
-  static final String ELECTION_REQUESTS = "election.requests";
-  static final String ELECTION_VOTES = "election.votes";
+  static final String ELECTION_EVENTS = "election.events";
 
   static final Serde<String> STRING_SERDE = Serdes.String();
-  static final Serde<CloudEvent> CLOUD_EVENT_SERDE = StreamUtils.getCESerde();
+  static Serde<Object> CLOUD_EVENT_SERDE;
 
   static Topology topology;
   static Properties properties;
   TopologyTestDriver testDriver;
-  TestInputTopic<String, CloudEvent> inputTopic;
-  TestOutputTopic<String, CloudEvent> outputTopic;
+  TestInputTopic<String, Object> inputTopic;
+  TestOutputTopic<String, Object> outputTopic;
 
   @BeforeAll
   static void build() {
@@ -46,12 +53,16 @@ class TTLTopologyTest {
     properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "election-ttl.test");
     properties.put("election.ttl", "PT15M");
     properties.put("input.topic", ELECTION_COMMANDS);
-    properties.put("output.topic.elections", ELECTION_REQUESTS);
-    properties.put("output.topic.votes", ELECTION_VOTES);
-
+    properties.put("output.topic", ELECTION_EVENTS);
+    properties.put(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    properties.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://mock");
+    properties.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+    properties.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true");
+    MockSchemaRegistryClient srClient = new MockSchemaRegistryClient();
+    CLOUD_EVENT_SERDE = StreamUtils.getAvroCESerde(srClient, properties);
 
     final StreamsBuilder builder = new StreamsBuilder();
-    topology = ElectionIntegrityTopology.buildTopology(builder, properties);
+    topology = ElectionIntegrityTopology.buildTopology(builder, properties, srClient);
   }
 
   @AfterEach
@@ -63,32 +74,45 @@ class TTLTopologyTest {
   void setup() {
     testDriver = new TopologyTestDriver(topology, properties);
     inputTopic = testDriver.createInputTopic(ELECTION_COMMANDS, STRING_SERDE.serializer(), CLOUD_EVENT_SERDE.serializer());
-    outputTopic = testDriver.createOutputTopic(ELECTION_REQUESTS, STRING_SERDE.deserializer(), CLOUD_EVENT_SERDE.deserializer());
+    outputTopic = testDriver.createOutputTopic(ELECTION_EVENTS, STRING_SERDE.deserializer(), CLOUD_EVENT_SERDE.deserializer());
   }
 
   @Test
   void test() {
-    final ElectionCreate election = new ElectionCreate("testAuthor", "testTitle", "test desc", "TEST", Arrays.asList("Foo", "Bar"));
+    final CreateElection election = CreateElection.newBuilder()
+            .setAuthor("testAuthor")
+            .setTitle("testTitle")
+            .setDescription("test desc")
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(Arrays.asList("Foo", "Bar"))
+            .build();
+
     inputTopic.pipeInput("userId0", TestCEBuilder.buildCE(election));
-    final KeyValue<String, CloudEvent> legalElection = outputTopic.readKeyValue();
+    final KeyValue<String, Object> legalElection = outputTopic.readKeyValue();
     assertThat(legalElection).isNotNull();
 
-    inputTopic.pipeInput(legalElection.key, TestCEBuilder.buildCE(legalElection.key, ElectionView.OPEN));
-    final CloudEvent voteEvent = TestCEBuilder.buildCE(new ElectionVote(legalElection.key, "Foo"));
-    inputTopic.pipeInput("userId0:" + legalElection.key, voteEvent);
-    inputTopic.pipeInput("userId1:" + legalElection.key, voteEvent);
-    inputTopic.pipeInput("userId2:" + legalElection.key, voteEvent);
-    assertThat(outputTopic.getQueueSize()).isZero();
+    inputTopic.pipeInput(legalElection.key, TestCEBuilder.buildCE(legalElection.key, ViewElection.newBuilder().setView(io.voting.events.enums.ElectionView.OPEN).setEId(legalElection.key).build()));
+    final CloudEvent voteEvent = TestCEBuilder.buildCE(RegisterVote.newBuilder().setEId(legalElection.key).setVotedFor("Foo").build());
+    inputTopic.pipeInput("userId0:" + legalElection.key, voteEvent); //legal vote
+    inputTopic.pipeInput("userId1:" + legalElection.key, voteEvent); //legal vote
+    inputTopic.pipeInput("userId2:" + legalElection.key, voteEvent); //legal vote
+    assertThat(outputTopic.readKeyValuesToList()).hasSize(3);
 
-    inputTopic.pipeInput(legalElection.key, TestCEBuilder.buildCE(legalElection.key, ElectionView.PENDING));
+    inputTopic.pipeInput(legalElection.key, TestCEBuilder.buildCE(legalElection.key, ViewElection.newBuilder().setEId(legalElection.key).setView(io.voting.events.enums.ElectionView.PENDING).build()));
     assertThat(outputTopic.getQueueSize()).isOne();
-    final KeyValue<String, CloudEvent> actualTTLEvent = outputTopic.readKeyValue();
+    final KeyValue<String, Object> actualTTLEvent = outputTopic.readKeyValue();
     assertThat(actualTTLEvent.key).isEqualTo(legalElection.key);
-    assertThat(new String(actualTTLEvent.value.getData().toBytes())).isEqualTo(legalElection.key);
-    assertThat(actualTTLEvent.value.getType()).isEqualTo(CloudEventTypes.ELECTION_EXPIRATION_EVENT);
+
+    final CloudEvent actualRecordValue = (CloudEvent)actualTTLEvent.value;
+    assertThat(actualRecordValue.getType()).isEqualTo(CloseElection.class.getName());
+    assertThat(actualRecordValue.getData()).isInstanceOf(AvroCloudEventData.class);
+
+    final CloseElection actualCEData = (CloseElection)AvroCloudEventData.<IntegrityEvent>dataOf(actualRecordValue.getData()).getLegalEvent();
+
+    assertThat(actualCEData.getEId()).hasToString(legalElection.key);
 
     // only PENDING
-    inputTopic.pipeInput(legalElection.key, TestCEBuilder.buildCE(legalElection.key, ElectionView.CLOSED));
+    inputTopic.pipeInput(legalElection.key, TestCEBuilder.buildCE(legalElection.key, ViewElection.newBuilder().setEId(legalElection.key).setView(ElectionView.CLOSED).build()));
     assertThat(outputTopic.getQueueSize()).isZero();
 
   }

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/VoteIntegrityTopologyTest.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/VoteIntegrityTopologyTest.java
@@ -1,8 +1,15 @@
 package io.voting.streams.electionintegrity.topology;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.utils.StreamUtils;
-import io.voting.common.library.models.ElectionVote;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.integrity.IntegrityEvent;
+import io.voting.events.integrity.NewVote;
 import io.voting.streams.electionintegrity.framework.TestCEBuilder;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -26,10 +33,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class VoteIntegrityTopologyTest {
 
+  static Serde<Object> CLOUD_EVENT_SERDE;
   static Topology topology;
   TopologyTestDriver testDriver;
-  TestInputTopic<String, CloudEvent> inputTopic;
-  TestOutputTopic<String, CloudEvent> outputTopic;
+  TestInputTopic<String, Object> inputTopic;
+  TestOutputTopic<String, Object> outputTopic;
   static Properties properties;
 
   @BeforeAll
@@ -37,21 +45,25 @@ class VoteIntegrityTopologyTest {
     properties = new Properties();
     properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "voting.test-"+ UUID.randomUUID());
     properties.put("input.topic", "input");
-    properties.put("output.topic.elections", "output_elections");
-    properties.put("output.topic.votes", "output_votes");
+    properties.put("output.topic", "output");
     properties.put("election.ttl", "P2D");
+    properties.put(CloudEventSerializer.ENCODING_CONFIG, "BINARY");
+    properties.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://mock");
+    properties.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true");
+    properties.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true");
+    MockSchemaRegistryClient srClient = new MockSchemaRegistryClient();
+    CLOUD_EVENT_SERDE = StreamUtils.getAvroCESerde(srClient, properties);
 
     final StreamsBuilder streamsBuilder = new StreamsBuilder();
-    topology = ElectionIntegrityTopology.buildTopology(streamsBuilder, properties);
+    topology = ElectionIntegrityTopology.buildTopology(streamsBuilder, properties, srClient);
   }
 
   @BeforeEach
   void setup() {
     testDriver = new TopologyTestDriver(topology, properties);
-    final Serde<CloudEvent> ceSerde = StreamUtils.getCESerde();
     final Serde<String> stringSerde = Serdes.String();
-    inputTopic = testDriver.createInputTopic(properties.getProperty("input.topic"), stringSerde.serializer(), ceSerde.serializer());
-    outputTopic = testDriver.createOutputTopic(properties.getProperty("output.topic.votes"), stringSerde.deserializer(), ceSerde.deserializer());
+    inputTopic = testDriver.createInputTopic(properties.getProperty("input.topic"), stringSerde.serializer(), CLOUD_EVENT_SERDE.serializer());
+    outputTopic = testDriver.createOutputTopic(properties.getProperty("output.topic"), stringSerde.deserializer(), CLOUD_EVENT_SERDE.deserializer());
   }
 
 
@@ -64,10 +76,10 @@ class VoteIntegrityTopologyTest {
   void test() {
     final String USER = "nerm";
     final String ELECTION = "001";
-    final ElectionVote v1 = new ElectionVote(ELECTION, "Bob");
-    final ElectionVote v2 = new ElectionVote(ELECTION, "Jack");
-    final ElectionVote v3 = new ElectionVote(ELECTION, "Nancy");
-    final ElectionVote v4 = new ElectionVote(ELECTION, "Jack");
+    final RegisterVote v1 = electionVote("Bob");
+    final RegisterVote v2 = electionVote("Jack");
+    final RegisterVote v3 = electionVote("Nancy");
+    final RegisterVote v4 = electionVote("Jack");
 
     final String EVENT_KEY = USER + ":" + ELECTION;
     inputTopic.pipeKeyValueList(
@@ -81,19 +93,27 @@ class VoteIntegrityTopologyTest {
             )
     );
     assertThat(outputTopic.getQueueSize()).isOne();
-    final KeyValue<String, CloudEvent> outputEvent = outputTopic.readKeyValue();
+    final KeyValue<String, Object> outputEvent = outputTopic.readKeyValue();
     assertThat(outputEvent.key).isEqualTo(ELECTION);
-    assertThat(outputEvent.value.getSubject()).isEqualTo(ELECTION);
-    assertThat(outputEvent.value.getData()).isNotNull();
-    final ElectionVote actualEvent = StreamUtils.unwrapCloudEventData(outputEvent.value.getData(), ElectionVote.class);
+    final CloudEvent actualValue = (CloudEvent) outputEvent.value;
+    assertThat(actualValue.getSubject()).isEqualTo(ELECTION);
+    assertThat(actualValue.getData()).isNotNull();
+    NewVote actualValueData = (NewVote) AvroCloudEventData.<IntegrityEvent>dataOf(actualValue.getData()).getLegalEvent();
 
     System.out.println();
     System.out.println(outputEvent);
-    System.out.println(actualEvent);
+    System.out.println(actualValueData);
     System.out.println();
 
-    assertThat(actualEvent).isEqualTo(ElectionVote.of(ELECTION, "Bob"));
+    assertThat(actualValueData).isEqualTo(NewVote.newBuilder().setEId(ELECTION).setCandidate("Bob").setUId(USER).build());
 
+  }
+
+  private RegisterVote electionVote(String votedFor) {
+    return RegisterVote.newBuilder()
+            .setEId("001")
+            .setVotedFor(votedFor)
+            .build();
   }
 
 }

--- a/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/predicates/IllegalContentProcessorTest.java
+++ b/election-integrity/src/test/java/io/voting/streams/electionintegrity/topology/predicates/IllegalContentProcessorTest.java
@@ -1,6 +1,7 @@
 package io.voting.streams.electionintegrity.topology.predicates;
 
-import io.voting.common.library.models.ElectionCreate;
+import io.voting.events.cmd.CreateElection;
+import io.voting.events.enums.ElectionCategory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ class IllegalContentProcessorTest {
   private static final String TITLE = "good_title";
   private static final String DESC = "good_description";
   private static final String CATEGORY = "good_category";
-  private static final List<String> CANDIDATES = Collections.singletonList("good_candidate");
+  private static final List<CharSequence> CANDIDATES = Collections.singletonList("good_candidate");
 
   private static IllegalContentProcessor processor;
 
@@ -27,34 +28,59 @@ class IllegalContentProcessorTest {
 
   @Test
   void safeEvent() {
-    final ElectionCreate electionCreate = new ElectionCreate(AUTHOR, TITLE, DESC, CATEGORY, CANDIDATES);
+    final CreateElection electionCreate = CreateElection.newBuilder()
+            .setAuthor(AUTHOR)
+            .setTitle(TITLE)
+            .setDescription(DESC)
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(CANDIDATES)
+            .build();
     assertThat(processor.test(null, electionCreate)).isFalse();
   }
 
   @Test
   void illegalTitle() {
-    final ElectionCreate electionCreate = new ElectionCreate(AUTHOR, "asshole", DESC, CATEGORY, CANDIDATES);
+    final CreateElection electionCreate = CreateElection.newBuilder()
+            .setAuthor(AUTHOR)
+            .setTitle("asshole")
+            .setDescription(DESC)
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(CANDIDATES)
+            .build();
     assertThat(processor.test(null, electionCreate)).isTrue();
   }
 
   @Test
   void illegalDescription() {
-    final ElectionCreate electionCreate = new ElectionCreate(AUTHOR, TITLE, "assh0le", CATEGORY, CANDIDATES);
+    final CreateElection electionCreate = CreateElection.newBuilder()
+            .setAuthor(AUTHOR)
+            .setTitle(TITLE)
+            .setDescription("assh0le")
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(CANDIDATES)
+            .build();
     assertThat(processor.test(null, electionCreate)).isTrue();
   }
 
-  @Test
-  void illegalCategory() {
-    final ElectionCreate electionCreate = new ElectionCreate(AUTHOR, TITLE, DESC, "FUCK", CANDIDATES);
-    assertThat(processor.test(null, electionCreate)).isTrue();
-  }
 
   @Test
   void illegalCandidate() {
-    final ElectionCreate electionCreate = new ElectionCreate(AUTHOR, TITLE, DESC, CATEGORY, Arrays.asList("Bob", "Asshton", "Bitch"));
+    final CreateElection electionCreate = CreateElection.newBuilder()
+            .setAuthor(AUTHOR)
+            .setTitle(TITLE)
+            .setDescription(DESC)
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(Arrays.asList("Bob", "Asshton", "Bitch"))
+            .build();
     assertThat(processor.test(null, electionCreate)).isTrue();
 
-    final ElectionCreate actuallySafe = new ElectionCreate(AUTHOR, TITLE, DESC, CATEGORY, Arrays.asList("Bob", "Asshton"));
+    final CreateElection actuallySafe = CreateElection.newBuilder()
+            .setAuthor(AUTHOR)
+            .setTitle(TITLE)
+            .setDescription(DESC)
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(Arrays.asList("Bob", "Asshton"))
+            .build();
     assertThat(processor.test(null, actuallySafe)).isFalse();
   }
 

--- a/event-sink/pom.xml
+++ b/event-sink/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.voting.persistence</groupId>
     <artifactId>event-sink</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.voting.common</groupId>
             <artifactId>library</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/event-sink/src/main/java/io/voting/persistence/eventsink/listener/ElectionCreateListener.java
+++ b/event-sink/src/main/java/io/voting/persistence/eventsink/listener/ElectionCreateListener.java
@@ -3,14 +3,18 @@ package io.voting.persistence.eventsink.listener;
 import io.cloudevents.CloudEvent;
 import io.voting.common.library.kafka.clients.listener.EventListener;
 import io.voting.common.library.kafka.clients.receiver.EventReceiver;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.models.ReceiveEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
-import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.common.library.models.Election;
+import io.voting.common.library.models.ElectionStatus;
+import io.voting.events.integrity.IntegrityEvent;
+import io.voting.events.integrity.NewElection;
 import io.voting.persistence.eventsink.dao.ElectionDao;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -33,16 +37,32 @@ public class ElectionCreateListener implements EventListener<String, CloudEvent>
     final Optional<CloudEvent> cloudEvent = Optional.of(event)
             .filter(e -> Objects.isNull(e.getPOrE().getError()))
             .map(e -> e.getPOrE().getPayload())
-            .filter(payload -> CloudEventTypes.ELECTION_CREATE_EVENT.equals(payload.getType()));
+            .filter(payload -> NewElection.class.getName().equals(payload.getType()));
     if (cloudEvent.isPresent()) {
-      log.debug("Processing {} : {}", CloudEventTypes.ELECTION_CREATE_EVENT, event);
+      log.debug("Processing {} : {}", NewElection.class.getName(), event);
       try {
-        final Election election = dao.insertElection(StreamUtils.unwrapCloudEventData(cloudEvent.get().getData(), Election.class));
+        final NewElection newElectionData = (NewElection) AvroCloudEventData.<IntegrityEvent>dataOf(cloudEvent.get().getData()).getLegalEvent();
+        final Election election = dao.insertElection(mapNewElection(newElectionData));
         log.debug("Result of election insert : {}", election);
       } catch (Exception e) {
         log.error("Unexpected exception occurred during election insert : {}", e.getMessage(), e);
       }
-
     }
+  }
+
+  private Election mapNewElection(final NewElection newElection) {
+    final Map<String, Long> cMap = new HashMap<>();
+    newElection.getCandidates().forEach((k,v) -> cMap.put(k.toString(), v));
+    return Election.builder()
+            .id(newElection.getId().toString())
+            .author(newElection.getAuthor().toString())
+            .title(newElection.getTitle().toString())
+            .description(newElection.getDescription().toString())
+            .category(newElection.getCategory().name())
+            .status(ElectionStatus.valueOf(newElection.getStatus().name()))
+            .candidates(cMap)
+            .startTs(newElection.getStartTs().toEpochMilli())
+            .endTs(newElection.getEndTs().toEpochMilli())
+            .build();
   }
 }

--- a/event-sink/src/main/java/io/voting/persistence/eventsink/listener/ElectionTTLListener.java
+++ b/event-sink/src/main/java/io/voting/persistence/eventsink/listener/ElectionTTLListener.java
@@ -4,9 +4,9 @@ import io.cloudevents.CloudEvent;
 import io.voting.common.library.kafka.clients.listener.EventListener;
 import io.voting.common.library.kafka.clients.receiver.EventReceiver;
 import io.voting.common.library.kafka.models.ReceiveEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
 import io.voting.common.library.models.Election;
 import io.voting.common.library.models.ElectionStatus;
+import io.voting.events.integrity.CloseElection;
 import io.voting.persistence.eventsink.dao.ElectionDao;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -30,9 +30,9 @@ public class ElectionTTLListener implements EventListener<String, CloudEvent> {
     final Optional<CloudEvent> cloudEvent = Optional.of(event)
             .filter(e -> Objects.isNull(e.getPOrE().getError()))
             .map(e -> e.getPOrE().getPayload())
-            .filter(payload -> CloudEventTypes.ELECTION_EXPIRATION_EVENT.equals(payload.getType()));
+            .filter(payload -> CloseElection.class.getName().equals(payload.getType()));
     if (cloudEvent.isPresent()) {
-      log.debug("Processing {} : {}", CloudEventTypes.ELECTION_EXPIRATION_EVENT, event);
+      log.debug("Processing {} : {}", CloseElection.class.getName(), event);
       try {
         final Election election = dao.updateElectionStatus(cloudEvent.get().getId(), ElectionStatus.CLOSED);
         log.debug("Result of Election TTL event : {}", election);

--- a/event-sink/src/main/java/io/voting/persistence/eventsink/listener/ElectionVoteListener.java
+++ b/event-sink/src/main/java/io/voting/persistence/eventsink/listener/ElectionVoteListener.java
@@ -3,11 +3,12 @@ package io.voting.persistence.eventsink.listener;
 import io.cloudevents.CloudEvent;
 import io.voting.common.library.kafka.clients.listener.EventListener;
 import io.voting.common.library.kafka.clients.receiver.EventReceiver;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.models.ReceiveEvent;
-import io.voting.common.library.kafka.utils.CloudEventTypes;
-import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.common.library.models.Election;
 import io.voting.common.library.models.ElectionVote;
+import io.voting.events.integrity.IntegrityEvent;
+import io.voting.events.integrity.NewVote;
 import io.voting.persistence.eventsink.dao.ElectionDao;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -31,11 +32,14 @@ public class ElectionVoteListener implements EventListener<String, CloudEvent> {
     final Optional<CloudEvent> cloudEvent = Optional.of(event)
             .filter(e -> Objects.isNull(e.getPOrE().getError()))
             .map(e -> e.getPOrE().getPayload())
-            .filter(payload -> CloudEventTypes.ELECTION_VOTE_EVENT.equals(payload.getType()));
+            .filter(payload -> NewVote.class.getName().equals(payload.getType()));
     if (cloudEvent.isPresent()) {
-      log.debug("Processing {} : {}", CloudEventTypes.ELECTION_VOTE_EVENT, event);
+      log.debug("Processing {} : {}", NewVote.class.getName(), event);
       try {
-        final Election election = dao.updateElection(StreamUtils.unwrapCloudEventData(cloudEvent.get().getData(), ElectionVote.class));
+        final NewVote newVoteData = (NewVote) AvroCloudEventData.<IntegrityEvent>dataOf(cloudEvent.get().getData()).getLegalEvent();
+        final Election election = dao.updateElection(
+                ElectionVote.of(newVoteData.getEId().toString(), newVoteData.getCandidate().toString())
+        );
         log.debug("Result of election update : {}", election);
       } catch (Exception e) {
         log.error("Unexpected exception occurred during election update : {}", e.getMessage(), e);

--- a/event-sink/src/main/resources/application-test.yml
+++ b/event-sink/src/main/resources/application-test.yml
@@ -6,14 +6,19 @@ kafka:
     security.protocol: SASL_PLAINTEXT
     sasl.mechanism: PLAIN
     sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="{file:/mnt/kafka-secrets/secrets.txt:username}" password="{file:/mnt/kafka-secrets/secrets.txt:password}";
+    schema.registry.url: https://sr.cfk.svc.cluster.local:8081
+    schema.registry.basic.auth.user.info: "{file:/mnt/kafka-secrets/secrets.txt:username}:{file:/mnt/kafka-secrets/secrets.txt:password}"
+    schema.registry.basic.auth.credentials.source: USER_INFO
+    schema.registry.ssl.truststore.location: /mnt/tls/truststore.jks
+    schema.registry.ssl.truststore.password: {file:/mnt/kafka-secrets/secrets.txt:trust_password}
+    specific.avro.reader: true
   consumer:
     group.id: test.event.sink
     auto.offset.reset: earliest
     enable.auto.commit: false
     poll.duration: 500
   consumer-topics:
-    - test.election.requests
-    - test.election.votes
+    - edv.election.events
 
 spring:
   data:

--- a/event-sink/src/test/java/io/voting/persistence/eventsink/framework/SchemaRegistryContainer.java
+++ b/event-sink/src/test/java/io/voting/persistence/eventsink/framework/SchemaRegistryContainer.java
@@ -1,0 +1,34 @@
+package io.voting.persistence.eventsink.framework;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
+
+  public static final String SCHEMA_REGISTRY_IMAGE = "confluentinc/cp-schema-registry";
+  public static final int SCHEMA_REGISTRY_PORT = 8081;
+
+  public SchemaRegistryContainer() {
+    this("7.6.1");
+  }
+
+  public SchemaRegistryContainer(String version) {
+    super(SCHEMA_REGISTRY_IMAGE + ":" + version);
+
+    waitingFor(Wait.forHttp("/subjects").forStatusCode(200));
+    withExposedPorts(SCHEMA_REGISTRY_PORT);
+  }
+
+  public SchemaRegistryContainer withKafka(KafkaContainer kafka) {
+    return withKafkaC(kafka);
+  }
+
+  public SchemaRegistryContainer withKafkaC(KafkaContainer kafka) {
+    withNetwork(kafka.getNetwork());
+    withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry");
+    withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:"+SCHEMA_REGISTRY_PORT);
+    withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "kafka:19092");
+    return self();
+  }
+}

--- a/event-sink/src/test/java/io/voting/persistence/eventsink/framework/TestKafkaContext.java
+++ b/event-sink/src/test/java/io/voting/persistence/eventsink/framework/TestKafkaContext.java
@@ -1,6 +1,7 @@
 package io.voting.persistence.eventsink.framework;
 
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
@@ -8,11 +9,21 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class TestKafkaContext {
 
   public static final KafkaContainer kafkaContainer;
+  public static final SchemaRegistryContainer srContainer;
 
   static {
     kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"))
+            .withKraft()
+            .withListener(() -> "kafka:19092")
+            .withNetwork(Network.SHARED)
             .withEnv("KAFKA_NUM_PARTITIONS", "1");
     kafkaContainer.start();
+    srContainer = new SchemaRegistryContainer().withKafka(kafkaContainer);
+    srContainer.start();
+  }
+
+  public static String schemaRegistryUrl() {
+    return "http://" + srContainer.getHost() + ":" + srContainer.getFirstMappedPort();
   }
 
 }

--- a/event-sink/src/test/java/io/voting/persistence/eventsink/listener/ElectionCreateListenerTest.java
+++ b/event-sink/src/test/java/io/voting/persistence/eventsink/listener/ElectionCreateListenerTest.java
@@ -4,6 +4,7 @@ import com.github.javafaker.Faker;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.v1.CloudEventBuilder;
 import io.voting.common.library.kafka.clients.listener.EventListener;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
 import io.voting.common.library.kafka.models.PayloadOrError;
 import io.voting.common.library.kafka.models.ReceiveEvent;
 import io.voting.common.library.kafka.utils.CloudEventTypes;
@@ -11,6 +12,9 @@ import io.voting.common.library.kafka.utils.StreamUtils;
 import io.voting.common.library.models.Election;
 import io.voting.common.library.models.ElectionStatus;
 import io.voting.common.library.models.ElectionVote;
+import io.voting.events.enums.ElectionCategory;
+import io.voting.events.integrity.IntegrityEvent;
+import io.voting.events.integrity.NewElection;
 import io.voting.persistence.eventsink.dao.ElectionDao;
 import io.voting.persistence.eventsink.framework.TestReceiver;
 import org.junit.jupiter.api.Assertions;
@@ -18,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -39,13 +44,24 @@ class ElectionCreateListenerTest {
 
   @Test
   void testElectionCreateEvent() {
-    final Election election = new Election(null, fake.funnyName().name(), fake.lordOfTheRings().location(), fake.lorem().sentence(), "TEST", Map.of("Foo", 0L, "Bar", 0L), 0L, 0L, ElectionStatus.OPEN);
+    final NewElection election = NewElection.newBuilder()
+            .setId("123")
+            .setAuthor(fake.funnyName().name())
+            .setTitle(fake.lordOfTheRings().location())
+            .setDescription(fake.lorem().sentence())
+            .setCategory(ElectionCategory.Random)
+            .setCandidates(Map.of("Foo", 0L, "Bar", 0L))
+            .setStartTs(Instant.now())
+            .setEndTs(Instant.now())
+            .setStatus(io.voting.events.enums.ElectionStatus.OPEN)
+            .build();
+
     final CloudEvent ce = new CloudEventBuilder()
             .withId(UUID.randomUUID().toString())
             .withSource(URI.create("http://test"))
             .withSubject("TEST")
-            .withType(CloudEventTypes.ELECTION_CREATE_EVENT)
-            .withData(StreamUtils.wrapCloudEventData(election))
+            .withType(NewElection.class.getName())
+            .withData(AvroCloudEventData.MIME_TYPE, new AvroCloudEventData<>(new IntegrityEvent(election)))
             .build();
     listener.onEvent(new ReceiveEvent<>("test", 0, 0L, 0L, null, new PayloadOrError<>(ce, null, "unit test event")));
     assertThat(mockDao.electionCount()).isOne();

--- a/event-sink/src/test/resources/application.properties
+++ b/event-sink/src/test/resources/application.properties
@@ -3,7 +3,7 @@ spring.data.mongodb.host=localhost
 spring.data.mongodb.port=27017
 spring.data.mongodb.database=edv
 
-kafka.consumer-topics=election.votes, election.requests
+kafka.consumer-topics=election.events
 kafka.consumer.group.id=event.sink.itest
 kafka.consumer.enable.auto.commit=false
 kafka.consumer.poll.duration=100

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -12,12 +12,23 @@
 
     <groupId>io.voting.common</groupId>
     <artifactId>library</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
         <spring-boot.repackage.skip>true</spring-boot.repackage.skip>
+<!--        <schema.registry.url>http://localhost:8081</schema.registry.url>-->
+        <schema.registry.url>https://sr.local.nermdev.io</schema.registry.url>
+        <truststore.password></truststore.password>
+        <schema.registry.basic.auth.user.info></schema.registry.basic.auth.user.info>
     </properties>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>
@@ -44,10 +55,157 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${avro.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
+                            <imports>
+                                <import>${project.basedir}/src/main/avro/enums/ElectionCategory.avsc</import>
+                                <import>${project.basedir}/src/main/avro/enums/ElectionStatus.avsc</import>
+                                <import>${project.basedir}/src/main/avro/cmd/CreateElection.avsc</import>
+                                <import>${project.basedir}/src/main/avro/cmd/ViewElection.avsc</import>
+                                <import>${project.basedir}/src/main/avro/cmd/RegisterVote.avsc</import>
+                                <import>${project.basedir}/src/main/avro/cmd/CmdEvent.avsc</import>
+                                <import>${project.basedir}/src/main/avro/integrity/NewElection.avsc</import>
+                                <import>${project.basedir}/src/main/avro/integrity/NewVote.avsc</import>
+                                <import>${project.basedir}/src/main/avro/integrity/CloseElection.avsc</import>
+                                <import>${project.basedir}/src/main/avro/integrity/IntegrityEvent.avsc</import>
+                            </imports>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-schema-registry-maven-plugin</artifactId>
+                <version>${confluent.version}</version>
+                <configuration>
+                    <schemaRegistryUrls>${schema.registry.url}</schemaRegistryUrls>
+                    <subjects>
+                        <edv.election-category>${project.basedir}/src/main/avro/enums/ElectionCategory.avsc</edv.election-category>
+                        <edv.create-election-cmd>${project.basedir}/src/main/avro/cmd/CreateElection.avsc</edv.create-election-cmd>
+                        <edv.view-election-cmd>${project.basedir}/src/main/avro/cmd/ViewElection.avsc</edv.view-election-cmd>
+                        <edv.register-vote-cmd>${project.basedir}/src/main/avro/cmd/RegisterVote.avsc</edv.register-vote-cmd>
+                        <edv.election.commands-value>${project.basedir}/src/main/avro/cmd/CmdEvent.avsc</edv.election.commands-value>
+                        <edv.election-status>${project.basedir}/src/main/avro/enums/ElectionStatus.avsc</edv.election-status>
+                        <edv.new-election-integrity>${project.basedir}/src/main/avro/integrity/NewElection.avsc</edv.new-election-integrity>
+                        <edv.new-vote-integrity>${project.basedir}/src/main/avro/integrity/NewVote.avsc</edv.new-vote-integrity>
+                        <edv.close-election-integrity>${project.basedir}/src/main/avro/integrity/CloseElection.avsc</edv.close-election-integrity>
+                        <edv.election.events-value>${project.basedir}/src/main/avro/integrity/IntegrityEvent.avsc</edv.election.events-value>
+                    </subjects>
+                    <references>
+                        <edv.create-election-cmd>
+                            <reference>
+                                <name>io.voting.events.enums.ElectionCategory</name>
+                                <subject>edv.election-category</subject>
+                            </reference>
+                        </edv.create-election-cmd>
+                        <edv.election.commands-value>
+                            <reference>
+                                <name>io.voting.events.cmd.ElectionCreate</name>
+                                <subject>edv.create-election-cmd</subject>
+                            </reference>
+                            <reference>
+                                <name>io.voting.events.cmd.ViewElection</name>
+                                <subject>edv.view-election-cmd</subject>
+                            </reference>
+                            <reference>
+                                <name>io.voting.events.cmd.RegisterVote</name>
+                                <subject>edv.register-vote-cmd</subject>
+                            </reference>
+                        </edv.election.commands-value>
+
+                        <edv.new-election-integrity>
+                            <reference>
+                                <name>io.voting.events.enums.ElectionCategory</name>
+                                <subject>edv.election-category</subject>
+                            </reference>
+                            <reference>
+                                <name>io.voting.events.enums.ElectionStatus</name>
+                                <subject>edv.election-status</subject>
+                            </reference>
+                        </edv.new-election-integrity>
+                        <edv.election.events-value>
+                            <reference>
+                                <name>io.voting.events.integrity.NewElection</name>
+                                <subject>edv.new-election-integrity</subject>
+                            </reference>
+                            <reference>
+                                <name>io.voting.events.integrity.NewVote</name>
+                                <subject>edv.new-vote-integrity</subject>
+                            </reference>
+                            <reference>
+                                <name>io.voting.events.integrity.CloseElection</name>
+                                <subject>edv.close-election-integrity</subject>
+                            </reference>
+                        </edv.election.events-value>
+                    </references>
+                    <schemaTypes>
+                        <edv.election-category>AVRO</edv.election-category>
+                        <edv.create-election-cmd>AVRO</edv.create-election-cmd>
+                        <edv.view-election-cmd>AVRO</edv.view-election-cmd>
+                        <edv.register-vote-cmd>AVRO</edv.register-vote-cmd>
+                        <edv.election.commands-value>AVRO</edv.election.commands-value>
+                        <edv.election-status>AVRO</edv.election-status>
+                        <edv.new-election-integrity>AVRO</edv.new-election-integrity>
+                        <edv.new-vote-integrity>AVRO</edv.new-vote-integrity>
+                        <edv.close-election-integrity>AVRO</edv.close-election-integrity>
+                        <edv.election.events-value>AVRO</edv.election.events-value>
+                    </schemaTypes>
+                    <compatibilityLevels>
+                        <edv.election-category>BACKWARD</edv.election-category>
+                        <edv.create-election-cmd>BACKWARD</edv.create-election-cmd>
+                        <edv.view-election-cmd>BACKWARD</edv.view-election-cmd>
+                        <edv.register-vote-cmd>BACKWARD</edv.register-vote-cmd>
+                        <edv.election.commands-value>BACKWARD</edv.election.commands-value>
+                        <edv.election-status>BACKWARD</edv.election-status>
+                        <edv.new-election-integrity>BACKWARD</edv.new-election-integrity>
+                        <edv.new-vote-integrity>BACKWARD</edv.new-vote-integrity>
+                        <edv.close-election-integrity>BACKWARD</edv.close-election-integrity>
+                        <edv.election.events-value>BACKWARD</edv.election.events-value>
+                    </compatibilityLevels>
+                    <messagePath/>
+                    <outputDirectory/>
+                    <outputPath/>
+                    <previousSchemaPaths/>
+                    <schemas/>
+                    <userInfoConfig>${schema.registry.basic.auth.user.info}</userInfoConfig>
+                    <configs>
+                        <schema.registry.ssl.truststore.location>/Users/nerm/PycharmProjects/homelab/workspace/kafka/auth/nermin/truststore.jks</schema.registry.ssl.truststore.location>
+                        <schema.registry.ssl.truststore.password>${truststore.password}</schema.registry.ssl.truststore.password>
+                    </configs>
+                </configuration>
+            </plugin>
+
+
+
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>

--- a/library/src/main/avro/cmd/CmdEvent.avsc
+++ b/library/src/main/avro/cmd/CmdEvent.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "CmdEvent",
+  "namespace": "io.voting.events.cmd",
+  "doc": "Events emitted from the cmd-bridge component",
+  "fields": [
+    {
+      "name": "cmd",
+      "type": [
+        "io.voting.events.cmd.CreateElection",
+        "io.voting.events.cmd.ViewElection",
+        "io.voting.events.cmd.RegisterVote"
+      ]
+    }
+  ]
+}

--- a/library/src/main/avro/cmd/CreateElection.avsc
+++ b/library/src/main/avro/cmd/CreateElection.avsc
@@ -1,0 +1,47 @@
+{
+  "type": "record",
+  "name": "CreateElection",
+  "doc": "Data entered by user when creating a new election",
+  "namespace": "io.voting.events.cmd",
+  "fields": [
+    {
+      "name": "author",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "The username of the client requesting new election be created"
+    },
+    {
+      "name": "title",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "The name of the election"
+    },
+    {
+      "name": "description",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "A explanation of what the election is targeting from audience, applicable when title is not sufficient"
+    },
+    {
+      "name": "category",
+      "type": "io.voting.events.enums.ElectionCategory",
+      "doc": "The high-level subject/scope of the election"
+    },
+    {
+      "name": "candidates",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "avro.java.string": "String"
+        }
+      }
+    }
+  ]
+}

--- a/library/src/main/avro/cmd/RegisterVote.avsc
+++ b/library/src/main/avro/cmd/RegisterVote.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "RegisterVote",
+  "namespace": "io.voting.events.cmd",
+  "doc": "Data sent by frontend when user submits election vote",
+  "fields": [
+    {
+      "name": "eId",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "Election ID"
+    },
+    {
+      "name": "votedFor",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "Candidate selected from election"
+    }
+  ]
+}

--- a/library/src/main/avro/cmd/ViewElection.avsc
+++ b/library/src/main/avro/cmd/ViewElection.avsc
@@ -1,0 +1,27 @@
+{
+  "type": "record",
+  "name": "ViewElection",
+  "namespace": "io.voting.events.cmd",
+  "doc": "Data sent each time user queries a specific election",
+  "fields": [
+    {
+      "name": "eId",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      }
+    },
+    {
+      "name": "view",
+      "type": {
+        "type": "enum",
+        "name": "io.voting.events.enums.ElectionView",
+        "symbols": [
+          "OPEN", "PENDING", "CLOSED", "UNKNOWN"
+        ],
+        "default": "UNKNOWN"
+      },
+      "default": "UNKNOWN"
+    }
+  ]
+}

--- a/library/src/main/avro/enums/ElectionCategory.avsc
+++ b/library/src/main/avro/enums/ElectionCategory.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "enum",
+  "name": "ElectionCategory",
+  "namespace": "io.voting.events.enums",
+  "doc": "A high-level scope of what the election is about",
+  "symbols": [
+    "Social", "Music", "Sports", "Politics", "Gaming", "Random", "Unknown"
+  ],
+  "default": "Unknown"
+}

--- a/library/src/main/avro/enums/ElectionStatus.avsc
+++ b/library/src/main/avro/enums/ElectionStatus.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "enum",
+  "name": "ElectionStatus",
+  "namespace": "io.voting.events.enums",
+  "doc": "Represents the state of an Election",
+  "symbols": [
+    "OPEN", "CLOSED"
+  ]
+}

--- a/library/src/main/avro/integrity/CloseElection.avsc
+++ b/library/src/main/avro/integrity/CloseElection.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "CloseElection",
+  "namespace": "io.voting.events.integrity",
+  "doc": "Election that is due for closing / TTL expiration",
+  "fields": [
+    {
+      "name": "eId",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "Election ID"
+    }
+  ]
+}

--- a/library/src/main/avro/integrity/IntegrityEvent.avsc
+++ b/library/src/main/avro/integrity/IntegrityEvent.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "IntegrityEvent",
+  "namespace": "io.voting.events.integrity",
+  "doc": "Events emitted from election-integrity component",
+  "fields": [
+    {
+      "name": "legalEvent",
+      "type": [
+        "io.voting.events.integrity.NewElection",
+        "io.voting.events.integrity.NewVote",
+        "io.voting.events.integrity.CloseElection"
+      ]
+    }
+  ]
+}

--- a/library/src/main/avro/integrity/NewElection.avsc
+++ b/library/src/main/avro/integrity/NewElection.avsc
@@ -1,0 +1,74 @@
+{
+  "type": "record",
+  "name": "NewElection",
+  "namespace": "io.voting.events.integrity",
+  "doc": "New legal election to persist",
+  "fields": [
+    {
+      "name": "id",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "Election UUID"
+    },
+    {
+      "name": "author",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "Username of user that created the election"
+    },
+    {
+      "name": "title",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "The name of the election"
+    },
+    {
+      "name": "description",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "A explanation of what the election is targeting from audience, applicable when title is not sufficient"
+    },
+    {
+      "name": "category",
+      "type": "io.voting.events.enums.ElectionCategory",
+      "doc": "The high-level subject/scope of the election"
+    },
+    {
+      "name": "candidates",
+      "type": {
+        "type": "map",
+        "values": "long"
+      },
+      "doc": "Key/Value pairs containing election candidate / votes for election candidate"
+    },
+    {
+      "name": "startTs",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "UTC epoch ms timestamp of election TTL start"
+    },
+    {
+      "name": "endTs",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "UTC epoch ms timestamp of election TTL end"
+    },
+    {
+      "name": "status",
+      "type": "io.voting.events.enums.ElectionStatus",
+      "doc": "The state of the election"
+    }
+  ]
+}

--- a/library/src/main/avro/integrity/NewVote.avsc
+++ b/library/src/main/avro/integrity/NewVote.avsc
@@ -1,0 +1,32 @@
+{
+  "type": "record",
+  "name": "NewVote",
+  "namespace": "io.voting.events.integrity",
+  "doc": "New legal election vote to persist",
+  "fields": [
+    {
+      "name": "eId",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "Election ID"
+    },
+    {
+      "name": "candidate",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "The selected candidate from election user is voting for"
+    },
+    {
+      "name": "uId",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "User ID"
+    }
+  ]
+}

--- a/library/src/main/java/io/voting/common/library/kafka/clients/serialization/avro/AvroCloudEventData.java
+++ b/library/src/main/java/io/voting/common/library/kafka/clients/serialization/avro/AvroCloudEventData.java
@@ -1,0 +1,40 @@
+package io.voting.common.library.kafka.clients.serialization.avro;
+
+import io.cloudevents.CloudEventData;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.avro.generic.IndexedRecord;
+
+import java.util.Objects;
+
+@ToString
+@EqualsAndHashCode
+@Getter
+public class AvroCloudEventData<T extends IndexedRecord> implements CloudEventData {
+
+  public static final String MIME_TYPE = "application/avro";
+
+  public final T value;
+  public AvroCloudEventData(final T value){
+    this.value = Objects.requireNonNull(value);
+  }
+
+  @Override
+  public byte[] toBytes() {
+    return new byte[]{};
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <V extends IndexedRecord> V dataOf(CloudEventData data) {
+
+    if(data instanceof AvroCloudEventData){
+
+      return ((AvroCloudEventData<V>)data).getValue();
+
+    } else {
+      throw new IllegalArgumentException("data argument must be an instance of "
+              + AvroCloudEventData.class.getName());
+    }
+  }
+}

--- a/library/src/main/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventDeserializer.java
+++ b/library/src/main/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventDeserializer.java
@@ -1,0 +1,42 @@
+package io.voting.common.library.kafka.clients.serialization.avro;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.kafka.CloudEventDeserializer;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.header.Headers;
+
+import java.util.Map;
+
+
+@Slf4j
+public class KafkaAvroCloudEventDeserializer extends KafkaAvroDeserializer {
+
+    private final CloudEventDeserializer deserializer = new CloudEventDeserializer();
+
+    public KafkaAvroCloudEventDeserializer() {}
+    public KafkaAvroCloudEventDeserializer(SchemaRegistryClient registry) {
+        super(registry);
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        log.debug("Deserializer config: {}", configs);
+        super.configure(configs, isKey);
+        deserializer.configure(configs, isKey);
+    }
+
+    @Override
+    public CloudEvent deserialize(String topic, Headers headers, byte[] bytes) {
+        final Object value = super.deserialize(topic, headers, bytes);
+        final AvroCloudEventData<GenericRecord> data = new AvroCloudEventData<>((GenericRecord) value);
+        final CloudEvent event = deserializer.deserialize(topic, headers, bytes);
+        return CloudEventBuilder
+            .from(event)
+            .withData(AvroCloudEventData.MIME_TYPE, data)
+            .build();
+    }
+}

--- a/library/src/main/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventSerializer.java
+++ b/library/src/main/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventSerializer.java
@@ -1,0 +1,221 @@
+package io.voting.common.library.kafka.clients.serialization.avro;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.message.Encoding;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+public class KafkaAvroCloudEventSerializer extends KafkaAvroSerializer {
+
+  public static final String DATA_SCHEMA_HEADER = "ce_dataschema";
+
+  private final CloudEventSerializer serializer = new CloudEventSerializer();
+  private String schemaRegistryUrl;
+
+  public KafkaAvroCloudEventSerializer() {
+  }
+
+  public KafkaAvroCloudEventSerializer(SchemaRegistryClient client) {
+    super(client);
+  }
+
+  private Encoding encodingOf(Map<String, ?> configs) {
+    log.debug("Serializer config: {}", configs);
+
+    Object encodingConfig = configs.get(CloudEventSerializer.ENCODING_CONFIG);
+    Encoding encoding = null;
+
+    if (encodingConfig instanceof String ec) {
+      encoding = Encoding.valueOf(ec);
+    } else if (encodingConfig instanceof Encoding ec) {
+      encoding = ec;
+    } else if (encodingConfig != null) {
+      throw new IllegalArgumentException(CloudEventSerializer.ENCODING_CONFIG + " can be of type String or " + Encoding.class.getCanonicalName());
+    }
+
+    return encoding;
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    final Encoding encoding = encodingOf(configs);
+
+    if (encoding == Encoding.BINARY) {
+      super.configure(configs, isKey);
+      serializer.configure(configs, isKey);
+      schemaRegistryUrl = (String) configs.get(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
+
+      log.debug("{}={}", AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
+    } else {
+      throw new IllegalArgumentException(CloudEventSerializer.ENCODING_CONFIG + "=" + encoding + " not supported");
+    }
+  }
+
+  @Override
+  public byte[] serialize(String topic, Headers headers, Object event) {
+    if (!(event instanceof CloudEvent ceEvent)) {
+      throw new IllegalArgumentException("event argument must be an instance of " + CloudEvent.class);
+    }
+
+    serializer.serialize(topic, headers, ceEvent);
+    log.debug("CloudEvent headers : {}", headers);
+
+
+    if (ceEvent.getData() instanceof AvroCloudEventData<?> data) {
+      final IndexedRecord value = data.getValue();
+      final Class<? extends IndexedRecord> valueType = value.getClass();
+      log.debug("Payload to serialize as avro {}", value);
+
+      final byte[] bytes = super.serialize(topic, headers, data.getValue());
+
+      final String subjectName = getSubjectName(topic, valueType);
+      log.trace("SubjectName {}", subjectName);
+
+      final int version = getSubjectVersion(subjectName);
+      log.trace("Schema versionId {}", version);
+
+      final String dataschema = schemaRegistryUrl + "/subjects/" + subjectName + "/versions/" + version + "/schema";
+      log.debug("{}={}", DATA_SCHEMA_HEADER, dataschema);
+
+      headers.remove(DATA_SCHEMA_HEADER);
+      headers.add(DATA_SCHEMA_HEADER, dataschema.getBytes());
+
+      return bytes;
+
+    } else {
+      throw new IllegalArgumentException("CloudEvent data attribute must be an instance of "
+              + AvroCloudEventData.class.getName());
+    }
+  }
+
+  private Integer getSubjectVersion(String subjectName) {
+    log.trace("Attempt to get subject version for {}", subjectName);
+    final Optional<SubjectSchema> cachedSchemaData = super.latestVersions.asMap()
+            .keySet()
+            .stream()
+            .filter(ss -> ss.getSubject().equals(subjectName))
+            .findAny();
+    log.debug("Cached schema data is present : {}", cachedSchemaData.isPresent());
+    return cachedSchemaData
+            .map(ss -> super.latestVersions.asMap().get(ss))
+            .map(ParsedSchema::version)
+            .orElseGet(() -> {
+              try {
+                log.debug("Querying for subject version for {}", subjectName);
+                final List<Integer> versions = super.schemaRegistry.getAllVersions(subjectName);
+                return versions.get(versions.size() - 1);
+              } catch (IOException | RestClientException e) {
+                throw new SerializationException(e.getMessage(), e);
+              }
+            });
+  }
+
+  private String getSubjectName(String topic, Class<? extends IndexedRecord> valueType) {
+    final SubjectNameStrategy strategy = (SubjectNameStrategy) super.valueSubjectNameStrategy;
+    log.debug("SubjectNameStrategy {}", strategy);
+
+    return strategy.subjectName(
+            topic,
+            Boolean.FALSE,
+            new NoSchema(valueType.getPackageName(), valueType.getSimpleName())
+    );
+  }
+
+  private static final class NoSchema implements ParsedSchema {
+
+    private final String namespace;
+    private final String name;
+
+    public NoSchema(String namespace, String name) {
+      this.namespace = Objects.requireNonNull(namespace);
+      this.name = Objects.requireNonNull(name);
+    }
+
+    @Override
+    public String canonicalString() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Integer version() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String name() {
+      return namespace + "." + name;
+    }
+
+    @Override
+    public Object rawSchema() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<SchemaReference> references() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Metadata metadata() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RuleSet ruleSet() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ParsedSchema copy() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ParsedSchema copy(Integer integer) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ParsedSchema copy(Metadata metadata, RuleSet ruleSet) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ParsedSchema copy(Map<SchemaEntity, Set<String>> map, Map<SchemaEntity, Set<String>> map1) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> isBackwardCompatible(ParsedSchema parsedSchema) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String schemaType() {
+      throw new UnsupportedOperationException();
+    }
+
+  }
+}

--- a/library/src/main/java/io/voting/common/library/kafka/clients/serialization/ce/AvroCEPayloadDeserializer.java
+++ b/library/src/main/java/io/voting/common/library/kafka/clients/serialization/ce/AvroCEPayloadDeserializer.java
@@ -1,0 +1,56 @@
+package io.voting.common.library.kafka.clients.serialization.ce;
+
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.kafka.CloudEventDeserializer;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.voting.common.library.kafka.clients.serialization.avro.AvroCloudEventData;
+import io.voting.common.library.kafka.models.PayloadOrError;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.header.Headers;
+
+import java.util.Map;
+
+@Slf4j
+public class AvroCEPayloadDeserializer extends KafkaAvroDeserializer {
+
+  private final CloudEventDeserializer deserializer = new CloudEventDeserializer();
+
+  public AvroCEPayloadDeserializer() {}
+  public AvroCEPayloadDeserializer(SchemaRegistryClient registry) {
+    super(registry);
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    log.debug("Deserializer config: {}", configs);
+    super.configure(configs, isKey);
+    deserializer.configure(configs, isKey);
+  }
+
+  @Override
+  public PayloadOrError<CloudEvent> deserialize(String topic, Headers headers, byte[] data) {
+    final String encoded = new String(data);
+    log.debug("Attempting to deserialize value (encoded) : {}", encoded);
+
+    try {
+      final Object dataValue = super.deserialize(topic, headers, data);
+      final AvroCloudEventData<GenericRecord> ceData = new AvroCloudEventData<>((GenericRecord) dataValue);
+      final CloudEvent event = deserializer.deserialize(topic, headers, data);
+      return new PayloadOrError<>(
+              CloudEventBuilder
+                      .from(event)
+                      .withData(AvroCloudEventData.MIME_TYPE, ceData)
+                      .build(),
+              null,
+              encoded
+      );
+    } catch (Exception e) {
+      log.error("Error deserializing payload ({}) : encoded value {}", topic, encoded, e);
+      return new PayloadOrError<>(null, e, encoded);
+    }
+  }
+}

--- a/library/src/main/java/io/voting/common/library/kafka/clients/serialization/ce/CEPayloadDeserializer.java
+++ b/library/src/main/java/io/voting/common/library/kafka/clients/serialization/ce/CEPayloadDeserializer.java
@@ -9,6 +9,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 
 import java.util.Map;
 
+@Deprecated
 @Slf4j
 public class CEPayloadDeserializer implements Deserializer<PayloadOrError<CloudEvent>> {
 

--- a/library/src/main/java/io/voting/common/library/kafka/clients/serialization/ce/CESerializer.java
+++ b/library/src/main/java/io/voting/common/library/kafka/clients/serialization/ce/CESerializer.java
@@ -4,6 +4,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.kafka.CloudEventSerializer;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
+@Deprecated
 public class CESerializer extends CloudEventSerializer {
 
   public CESerializer() {

--- a/library/src/main/java/io/voting/common/library/kafka/utils/StreamUtils.java
+++ b/library/src/main/java/io/voting/common/library/kafka/utils/StreamUtils.java
@@ -6,6 +6,9 @@ import io.cloudevents.CloudEventData;
 import io.cloudevents.core.data.PojoCloudEventData;
 import io.cloudevents.jackson.PojoCloudEventDataMapper;
 import io.cloudevents.kafka.CloudEventDeserializer;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.voting.common.library.kafka.clients.serialization.avro.KafkaAvroCloudEventDeserializer;
+import io.voting.common.library.kafka.clients.serialization.avro.KafkaAvroCloudEventSerializer;
 import io.voting.common.library.kafka.clients.serialization.ce.CESerializer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -17,6 +20,8 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 @Slf4j
@@ -32,9 +37,32 @@ public final class StreamUtils {
     return Serdes.serdeFrom(serializer,deserializer);
   }
 
-  public static Serde<CloudEvent> getCESerde() {
-    final Serializer<CloudEvent> serializer = new CESerializer();
-    final Deserializer<CloudEvent> deserializer = new CloudEventDeserializer();
+  public static Serde<Object> getAvroCESerde() {
+    final KafkaAvroCloudEventSerializer serializer = new KafkaAvroCloudEventSerializer();
+    final KafkaAvroCloudEventDeserializer deserializer = new KafkaAvroCloudEventDeserializer();
+    return Serdes.serdeFrom(serializer, deserializer);
+  }
+
+  public static Serde<Object> getAvroCESerde(final Properties properties) {
+    final Map<String, Object> config = propertiesToMap(properties);
+    return getAvroCESerde(config);
+  }
+
+  public static Serde<Object> getAvroCESerde(final Map<String, Object> config) {
+    final KafkaAvroCloudEventSerializer serializer = new KafkaAvroCloudEventSerializer();
+    final KafkaAvroCloudEventDeserializer deserializer = new KafkaAvroCloudEventDeserializer();
+    serializer.configure(config, false);
+    deserializer.configure(config, false);
+
+    return Serdes.serdeFrom(serializer, deserializer);
+  }
+
+  public static Serde<Object> getAvroCESerde(final SchemaRegistryClient srClient, final Properties properties) {
+    final Map<String, Object> map = propertiesToMap(properties);
+    final KafkaAvroCloudEventSerializer serializer = new KafkaAvroCloudEventSerializer(srClient);
+    final KafkaAvroCloudEventDeserializer deserializer = new KafkaAvroCloudEventDeserializer(srClient);
+    serializer.configure(map, false);
+    deserializer.configure(map, false);
     return Serdes.serdeFrom(serializer, deserializer);
   }
 
@@ -49,10 +77,27 @@ public final class StreamUtils {
     }
   }
 
+  public static Map<String,Object> propertiesToMap(final Properties properties) {
+    final Map<String, Object> configs = new HashMap<>();
+    properties.forEach(
+            (key, value) -> configs.put((String) key, value)
+    );
+    return configs;
+  }
+
+  @Deprecated
+  public static Serde<CloudEvent> getCESerde() {
+    final Serializer<CloudEvent> serializer = new CESerializer();
+    final Deserializer<CloudEvent> deserializer = new CloudEventDeserializer();
+    return Serdes.serdeFrom(serializer, deserializer);
+  }
+
+  @Deprecated
   public static <T> PojoCloudEventData<T> wrapCloudEventData(final T data) {
     return PojoCloudEventData.wrap(data, mapper::writeValueAsBytes);
   }
 
+  @Deprecated
   public static <T> T unwrapCloudEventData(final CloudEventData data, final Class<T> target) {
     return PojoCloudEventDataMapper.from(mapper, target).map(data).getValue();
   }

--- a/library/src/test/java/io/voting/common/library/kafka/clients/serialization/avro/AvroCloudEventDataTest.java
+++ b/library/src/test/java/io/voting/common/library/kafka/clients/serialization/avro/AvroCloudEventDataTest.java
@@ -1,0 +1,44 @@
+package io.voting.common.library.kafka.clients.serialization.avro;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.cmd.ViewElection;
+import io.voting.events.enums.ElectionView;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AvroCloudEventDataTest {
+
+  @Test
+  void testGetValue() {
+    final CmdEvent cmdEvent = new CmdEvent(new RegisterVote("eid", "FooBar"));
+    final AvroCloudEventData<CmdEvent> ceData = new AvroCloudEventData<>(cmdEvent);
+    assertEquals(cmdEvent, ceData.getValue());
+  }
+
+  @Test
+  void testWrappedValue() {
+    final CmdEvent cmdEvent = new CmdEvent(new ViewElection("eid", ElectionView.OPEN));
+    final AvroCloudEventData<CmdEvent> ceData = new AvroCloudEventData<>(cmdEvent);
+
+    final CloudEvent ce = CloudEventBuilder.v1()
+            .withId("")
+            .withSource(URI.create("/test"))
+            .withType(cmdEvent.getCmd().getClass().getName())
+            .withSubject("TEST")
+            .withTime(OffsetDateTime.now())
+            .withData(AvroCloudEventData.MIME_TYPE, ceData)
+            .build();
+
+    assertEquals(ceData, ce.getData());
+  }
+
+
+
+}

--- a/library/src/test/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventDeserializerTest.java
+++ b/library/src/test/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventDeserializerTest.java
@@ -1,0 +1,158 @@
+package io.voting.common.library.kafka.clients.serialization.avro;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.RegisterVote;
+import io.voting.events.cmd.ViewElection;
+import io.voting.events.enums.ElectionView;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KafkaAvroCloudEventDeserializerTest {
+
+  private static final String TOPIC = "test";
+  private static Map<String, Object> configs;
+
+  @BeforeAll
+  static void initConfigs() {
+    configs = new HashMap<>(Map.of(
+            CloudEventSerializer.ENCODING_CONFIG, "BINARY",
+            KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true",
+            KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://mock:8081"
+    ));
+  }
+
+  private SchemaRegistryClient srClient;
+  private KafkaAvroCloudEventDeserializer deserializer;
+  private KafkaAvroCloudEventSerializer serializer;
+
+  @BeforeEach
+  void setup() {
+    srClient = new MockSchemaRegistryClient();
+    serializer = new KafkaAvroCloudEventSerializer(srClient);
+    deserializer = new KafkaAvroCloudEventDeserializer(srClient);
+  }
+
+  @AfterEach
+  void remove() {
+    configs.remove(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG);
+    serializer.close();
+    deserializer.close();
+  }
+
+  @Test
+  void deserializeSpecificRecord() {
+    configs.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true");
+    serializer.configure(configs, false);
+    deserializer.configure(configs, false);
+
+    final CmdEvent cmdEvent = new CmdEvent(new RegisterVote("eid", "Foo"));
+    final AvroCloudEventData<CmdEvent> ceData = new AvroCloudEventData<>(cmdEvent);
+    final CloudEvent ce = CloudEventBuilder.v1()
+            .withId("")
+            .withSource(URI.create("/test"))
+            .withType(cmdEvent.getCmd().getClass().getName())
+            .withSubject("TEST")
+            .withTime(OffsetDateTime.now())
+            .withData(AvroCloudEventData.MIME_TYPE, ceData)
+            .build();
+
+    final Headers headers = new RecordHeaders();
+    final byte[] bytes = serializer.serialize(TOPIC, headers, ce);
+
+    final CloudEvent actualCe = deserializer.deserialize(TOPIC, headers, bytes);
+    final CloudEventData actualCeData = actualCe.getData();
+    assertTrue(actualCeData instanceof AvroCloudEventData);
+
+    @SuppressWarnings("unchecked")
+    final AvroCloudEventData<CmdEvent> actualAvroData = (AvroCloudEventData<CmdEvent>) actualCeData;
+    final CmdEvent actualCmdEvent = actualAvroData.getValue();
+
+    assertEquals(cmdEvent, actualCmdEvent);
+
+  }
+
+  @Test
+  void deserializeGenericRecord() {
+    configs.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "false");
+    serializer.configure(configs, false);
+    deserializer.configure(configs, false);
+
+    final RegisterVote registerVote = new RegisterVote("eid", "Foo");
+    final AvroCloudEventData<RegisterVote> ceData = new AvroCloudEventData<>(registerVote);
+    final CloudEvent ce = CloudEventBuilder.v1()
+            .withId("")
+            .withSource(URI.create("/test"))
+            .withType(registerVote.getClass().getName())
+            .withSubject("TEST")
+            .withTime(OffsetDateTime.now())
+            .withData(AvroCloudEventData.MIME_TYPE, ceData)
+            .build();
+
+    final Headers headers = new RecordHeaders();
+    final byte[] bytes = serializer.serialize(TOPIC, headers, ce);
+
+    final CloudEvent actualCe = deserializer.deserialize(TOPIC, headers, bytes);
+    final CloudEventData actualCeData = actualCe.getData();
+    assertTrue(actualCeData instanceof AvroCloudEventData);
+
+    @SuppressWarnings("unchecked")
+    final AvroCloudEventData<GenericRecord> actualAvroData = (AvroCloudEventData<GenericRecord>) actualCeData;
+    final GenericRecord actualRegisterVote = actualAvroData.getValue();
+
+    assertEquals(registerVote.getEId(), actualRegisterVote.get("eId").toString());
+    assertEquals(registerVote.getVotedFor(), actualRegisterVote.get("votedFor").toString());
+  }
+
+  @Test
+  void deserializeCloudEventMetadata() {
+    configs.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "false");
+    serializer.configure(configs, false);
+    deserializer.configure(configs, false);
+
+    final CmdEvent cmdEvent = new CmdEvent(new ViewElection("eid", ElectionView.OPEN));
+    final AvroCloudEventData<CmdEvent> ceData = new AvroCloudEventData<>(cmdEvent);
+    final CloudEvent ce = CloudEventBuilder.v1()
+            .withId("123")
+            .withSource(URI.create("/test"))
+            .withType(cmdEvent.getCmd().getClass().getName())
+            .withSubject("TEST")
+            .withTime(OffsetDateTime.now())
+            .withData(AvroCloudEventData.MIME_TYPE, ceData)
+            .build();
+
+    final Headers headers = new RecordHeaders();
+    final byte[] bytes = serializer.serialize(TOPIC, headers, ce);
+    final CloudEvent actualCe = deserializer.deserialize(TOPIC, headers, bytes);
+
+    assertEquals(ce.getId(), actualCe.getId());
+    assertEquals(ce.getSource(), actualCe.getSource());
+    assertEquals(ce.getType(), actualCe.getType());
+    assertEquals(ce.getSubject(), actualCe.getSubject());
+    assertEquals(ce.getTime(), actualCe.getTime());
+    assertNotNull(actualCe.getDataSchema());
+
+
+  }
+
+
+}

--- a/library/src/test/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventSerializerTest.java
+++ b/library/src/test/java/io/voting/common/library/kafka/clients/serialization/avro/KafkaAvroCloudEventSerializerTest.java
@@ -1,0 +1,75 @@
+package io.voting.common.library.kafka.clients.serialization.avro;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import io.voting.events.cmd.CmdEvent;
+import io.voting.events.cmd.ViewElection;
+import io.voting.events.enums.ElectionView;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KafkaAvroCloudEventSerializerTest {
+
+  @Test
+  void incompatibleEncoding() {
+    final Map<String, String> config = Map.of(
+            CloudEventSerializer.ENCODING_CONFIG, "STRUCTURED",
+            KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true",
+            KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://mock"
+    );
+    final KafkaAvroCloudEventSerializer serializer = new KafkaAvroCloudEventSerializer();
+    final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> serializer.configure(config, false));
+    serializer.close();
+    assertTrue(exception.getMessage().contains("not supported"));
+  }
+
+  @Test
+  void ceMetadataPresent() {
+    final SchemaRegistryClient srClient = new MockSchemaRegistryClient();
+    final KafkaAvroCloudEventSerializer serializer = new KafkaAvroCloudEventSerializer(srClient);
+    final Map<String, String> config = Map.of(
+            CloudEventSerializer.ENCODING_CONFIG, "BINARY",
+            KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "true",
+            KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://mock"
+    );
+    serializer.configure(config, false);
+
+    final CmdEvent cmdEvent = new CmdEvent(new ViewElection("eid", ElectionView.PENDING));
+    final AvroCloudEventData<CmdEvent> ceData = new AvroCloudEventData<>(cmdEvent);
+    final CloudEvent ce = CloudEventBuilder.v1()
+            .withId("")
+            .withSource(URI.create("/test"))
+            .withType(cmdEvent.getCmd().getClass().getName())
+            .withSubject("TEST")
+            .withTime(OffsetDateTime.now())
+            .withData(AvroCloudEventData.MIME_TYPE, ceData)
+            .build();
+    final Headers headers = new RecordHeaders();
+    serializer.serialize("topic", headers, ce);
+
+    assertTrue(headers.iterator().hasNext());
+    assertEquals("1.0", new String(headers.lastHeader("ce_specversion").value()));
+    assertEquals(ce.getId(), new String(headers.lastHeader("ce_id").value()));
+    assertEquals(ce.getSource().toString(), new String(headers.lastHeader("ce_source").value()));
+    assertEquals(ce.getType(), new String(headers.lastHeader("ce_type").value()));
+    assertEquals(ce.getDataContentType(), new String(headers.lastHeader("content-type").value()));
+    final Header header = headers.lastHeader(KafkaAvroCloudEventSerializer.DATA_SCHEMA_HEADER);
+    assertNotNull(header);
+    assertEquals("http://mock/subjects/topic-value/versions/1/schema", new String(header.value()));
+
+    serializer.close();
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,17 @@
         <lombok.version>1.18.30</lombok.version>
         <slf4j.version>2.0.11</slf4j.version>
         <cloudevent.version>2.3.0</cloudevent.version>
-        <image>registry.nermdev.io/apps/${project.artifactId}:${project.version}</image>
+        <confluent.version>7.6.0</confluent.version>
+        <avro.version>1.11.3</avro.version>
+        <image>registry.nermdev.io/edv/${project.artifactId}:${project.version}</image>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -143,6 +152,32 @@
                 <artifactId>spring-boot-starter-web</artifactId>
                 <version>${spring.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${avro.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-avro-serializer</artifactId>
+                <version>${confluent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-schema-rules</artifactId>
+                <version>${confluent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-schema-serializer</artifactId>
+                <version>${confluent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-schema-registry-client</artifactId>
+                <version>${confluent.version}</version>
+            </dependency>
+
 
             <!--     TEST DEPs       -->
             <dependency>

--- a/query-service/pom.xml
+++ b/query-service/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.voting.query</groupId>
     <artifactId>query-service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.voting.common</groupId>
             <artifactId>library</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/sandbox/scripts/create-topics.sh
+++ b/sandbox/scripts/create-topics.sh
@@ -1,32 +1,17 @@
 #!/usr/bin/env bash
 
-REQUESTS_RAW="election.requests.raw"
-REQUESTS="election.requests"
-
-VOTES_RAW="election.votes.raw"
-VOTES="election.votes"
-
+COMMANDS="election.commands"
+LEGAL_COMMANDS="election.events"
 
 kafka-topics \
   --bootstrap-server localhost:9092 \
-  --create --topic "$REQUESTS_RAW" \
+  --create --topic "$COMMANDS" \
   --partitions 1 \
   --replication-factor 1
 
 kafka-topics \
   --bootstrap-server localhost:9092 \
-  --create --topic "$REQUESTS" \
+  --create --topic "$LEGAL_COMMANDS" \
   --partitions 1 \
   --replication-factor 1
 
-kafka-topics \
-  --bootstrap-server localhost:9092 \
-  --create --topic "$VOTES_RAW" \
-  --partitions 1 \
-  --replication-factor 1
-
-kafka-topics \
-  --bootstrap-server localhost:9092 \
-  --create --topic "$VOTES" \
-  --partitions 1 \
-  --replication-factor 1


### PR DESCRIPTION
* feature/cloud-event-avro:

CloudEvent serializer/deserializer with avro data
stream utils update
Register CreateElection schema with embedded elum definition included to avoid intermittent fail resolving recursive reference when registering cmd-event schema Refactor mappers to use builders in case of new fields in future Refactor election-integrity to consume and produce avro cloud events Modify election-integrity to only produce to one output topic instead of two Refactor event-sink component to consume avro cloud events Refactor AvroCE serializer to minimize querying subject version / restful invoke docs
Bump version of components from 0.0.1 to 0.1.0
Dedicated image repo
Update deploy manifest / register schemas
Fix mistakes / address yarn error and wrap sr creds w string